### PR TITLE
Prevent exception handling from terminating execution

### DIFF
--- a/modules/commandModule/commandModule.py
+++ b/modules/commandModule/commandModule.py
@@ -73,7 +73,7 @@ class CommandModule:
         pigoFileDirectory: str
             String of POGI file directory
         """
-        self.__logger = logging.getLogger()
+        self.__logger = logging.getLogger(__name__)
         self.__pogiData = dict()
         self.__pigoData = dict()
         self.pogiFileDirectory = pogiFileDirectory
@@ -89,14 +89,16 @@ class CommandModule:
             with self.__pogiLock, open(self.pogiFileDirectory, "r") as pogiFile:
                 self.__pogiData = json.load(pogiFile)
         except json.decoder.JSONDecodeError:
-            raise json.decoder.JSONDecodeError("The given POGI file has no data to read")
+            self.__logger.error("The given POGI file has no data to read")
+            return None
 
     def __write_to_pigo_file(self):
         """
         Encodes pigoData dictionary as JSON and stores it in pigoFileDirectory JSON file
         """
         if not bool(self.__pigoData):
-            raise ValueError("The current PIGO data dictionary is empty")
+            self.__logger.error("The current PIGO data dictionary is empty")
+            return None
         with self.__pigoLock, open(self.pigoFileDirectory, "w") as pigoFile:
             json.dump(self.__pigoData, pigoFile, ensure_ascii=False, indent=4, sort_keys=True)
 
@@ -113,9 +115,11 @@ class CommandModule:
         errorCode = self.__pogiData["errorCode"]
 
         if errorCode is None:
-            raise ValueError("errorCode not found in the POGI json file")
+            self.__logger.error("errorCode not found in the POGI json file.")
+            return None
         if type(errorCode) is not int:
-            raise TypeError("errorCode found in POGI file is not an int")
+            self.__logger.error("errorCode found in POGI file is not an int.")
+            return None
         
         return errorCode
 
@@ -132,9 +136,11 @@ class CommandModule:
         currentAltitude = self.__pogiData["currentAltitude"]
 
         if currentAltitude is None:
-            raise ValueError("currentAltitude not found in the POGI json file. Exiting...")
+            self.__logger.error("currentAltitude not found in the POGI json file.")
+            return None
         if type(currentAltitude) is not int:
-            raise TypeError("currentAltitude in the POGI file was not an int. Exiting...")
+            self.__logger.error("currentAltitude in the POGI file is not an int.")
+            return None
 
         return currentAltitude
 
@@ -151,9 +157,11 @@ class CommandModule:
         currentAirspeed = self.__pogiData["currentAirspeed"]
 
         if currentAirspeed is None:
-            raise ValueError("currentAirspeed not found in the POGI json file. Exiting...")
+            self.__logger.error("currentAirspeed not found in the POGI json file.")
+            return None
         if type(currentAirspeed) is not int:
-            raise TypeError("currentAirspeed in the POGI file was not an int. Exiting...")
+            self.__logger.error("currentAirspeed in the POGI file is not an int.")
+            return None
 
         return currentAirspeed
 
@@ -170,9 +178,11 @@ class CommandModule:
         isLanded = self.__pogiData["isLanded"]
 
         if isLanded is None:
-            raise ValueError("isLanded not found in the POGI json file. Exiting...")
+            self.__logger.error("isLanded not found in the POGI json file.")
+            return None
         if type(isLanded) is not bool:
-            raise TypeError("isLanded in the POGI file was not an int. Exiting...")
+            self.__logger.error("isLanded in the POGI file is not an int.")
+            return None
 
         return isLanded
 
@@ -189,18 +199,23 @@ class CommandModule:
         eulerAnglesOfCamera = self.__pogiData["eulerAnglesOfCamera"]
 
         if eulerAnglesOfCamera is None:
-            raise ValueError("eulerAnglesOfCamera not found in the POGI json file. Exiting...")
+            self.__logger.error("eulerAnglesOfCamera not found in the POGI json file.")
+            return None
         if type(eulerAnglesOfCamera) is not dict:
-            raise TypeError("eulerAnglesOfCamera in the POGI file was not a float. Exiting...")
+            self.__logger.error("eulerAnglesOfCamera in the POGI file is not a dictionary.")
+            return None
         for key in ("z", "y", "x"):
             if key not in eulerAnglesOfCamera.keys():
-                raise KeyError("{} key not found in eulerAnglesOfCamera".format(key))
+                self.__logger.error("{} key not found in eulerAnglesOfCamera.".format(key))
+                return None
         for key in ("z", "y", "x"):
             if eulerAnglesOfCamera[key] is None:
-                raise ValueError("{} in eulerAnglesOfCamera is null".format(key))
+                self.__logger.error("{} in eulerAnglesOfCamera is null.".format(key))
+                return None
         for key in ("z", "y", "x"):
             if type(eulerAnglesOfCamera[key]) is not float:
-                raise TypeError("{} in eulerAnglesOfCamera must be a float".format(key))
+                self.__logger.error("{} in eulerAnglesOfCamera is not a float.".format(key))
+                return None
 
         return eulerAnglesOfCamera
 
@@ -217,18 +232,23 @@ class CommandModule:
         eulerAnglesOfPlane = self.__pogiData["eulerAnglesOfPlane"]
 
         if eulerAnglesOfPlane is None:
-            raise ValueError("eulerAnglesOfPlane not found in the POGI json file. Exiting...")
+            self.__logger.error("eulerAnglesOfPlane not found in the POGI json file.")
+            return None
         if type(eulerAnglesOfPlane) is not dict:
-            raise TypeError("eulerAnglesOfPlane in the POGI file was not a float. Exiting...")
+            self.__logger.error("eulerAnglesOfPlane in the POGI file is not a dictionary.")
+            return None
         for key in ("z", "y", "x"):
             if key not in eulerAnglesOfPlane.keys():
-                raise KeyError("{} key not found in eulerAnglesOfPlane".format(key))
+                self.__logger.error("{} key not found in eulerAnglesOfPlane.".format(key))
+                return None
         for key in ("z", "y", "x"):
             if eulerAnglesOfPlane[key] is None:
-                raise ValueError("{} in eulerAnglesOfPlane is null".format(key))
+                self.__logger.error("{} in eulerAnglesOfPlane is null.".format(key))
+                return None
         for key in ("z", "y", "x"):
             if type(eulerAnglesOfPlane[key]) is not float:
-                raise TypeError("{} in eulerAnglesOfPlane must be a float".format(key))
+                self.__logger.error("{} in eulerAnglesOfPlane is not a float.".format(key))
+                return None
 
         return eulerAnglesOfPlane
 
@@ -245,18 +265,23 @@ class CommandModule:
         gpsCoordinates = self.__pogiData["gpsCoordinates"]
 
         if gpsCoordinates is None:
-            raise ValueError("gpsCoordinates not found in the POGI json file. Exiting...")
+            self.__logger.error("gpsCoordinates not found in the POGI json file.")
+            return None
         if type(gpsCoordinates) is not dict:
-            raise TypeError("gpsCoordinates in the POGI file was not a float. Exiting...")
+            self.__logger.error("gpsCoordinates in the POGI file is not a dictionary.")
+            return None
         for key in ("latitude", "longitude", "altitude"):
             if key not in gpsCoordinates.keys():
-                raise KeyError("{} key not found in gpsCoordinates".format(key))
+                self.__logger.error("{} key not found in gpsCoordinates.".format(key))
+                return None
         for key in ("latitude", "longitude", "altitude"):
             if gpsCoordinates[key] is None:
-                raise ValueError("{} in gpsCoordinates is null".format(key))
+                self.__logger.error("{} in gpsCoordinates is null.".format(key))
+                return None
         for key in ("latitude", "longitude", "altitude"):
             if type(gpsCoordinates[key]) is not float:
-                raise TypeError("{} in gpsCoordinates must be a float".format(key))
+                self.__logger.error("{} in gpsCoordinates is not a float.".format(key))
+                return None
 
         return gpsCoordinates
 
@@ -270,15 +295,19 @@ class CommandModule:
             Dictionary that contains GPS coordinate data with latitude, longitude, and altitude
         """
         if gpsCoordinates is None:
-            raise ValueError("gpsCoordinates must be a dict and not None.")
+            self.__logger.error("gpsCoordinates must be a dict and not None.")
+            return None
         if type(gpsCoordinates) is not dict:
-            raise TypeError("gpsCoordinates must be a dict and not {}".format(type(gpsCoordinates)))
+            self.__logger.error("gpsCoordinates must be a dict and not {}.".format(type(gpsCoordinates)))
+            return None
         for attribute in ("latitude", "longitude", "altitude"):
             if attribute not in gpsCoordinates.keys():
-                raise KeyError("gpsCoordinates must contain {} key".format(attribute))
+                self.__logger.error("gpsCoordinates must contain {} key.".format(attribute))
+                return None
         for key in gpsCoordinates.keys():
             if type(gpsCoordinates[key]) is not float:
-                raise TypeError("gpsCoordinates {} key must be a float".format(key))
+                self.__logger.error("gpsCoordinates {} key must be a float.".format(key))
+                return None
 
         self.__pigoData.update({"gpsCoordinates" : gpsCoordinates})
         self.__write_to_pigo_file()
@@ -293,15 +322,19 @@ class CommandModule:
             Dictionary that contains ground commands with heading and latestDistance
         """
         if groundCommands is None:
-            raise ValueError("groundCommands must be a dict and not None.")
+            self.__logger.error("groundCommands must be a dict and not None.")
+            return None
         if type(groundCommands) is not dict:
-            raise TypeError("groundCommands must be a dict and not {}".format(type(groundCommands)))
+            self.__logger.error("groundCommands must be a dict and not {}.".format(type(groundCommands)))
+            return None
         for key in ("heading", "latestDistance"):
             if key not in groundCommands.keys():
-                raise KeyError("groundCommands must contain {} key".format(key))
+                self.__logger.error("groundCommands must contain {} key.".format(key))
+                return None
         for key in ("heading", "latestDistance"):
             if type(groundCommands[key]) is not float:
-                raise TypeError("groundCommands {} key must be a float".format(key))
+                self.__logger.error("groundCommands {} key must be a float.".format(key))
+                return None
 
         self.__pigoData.update({"groundCommands" : groundCommands})
         self.__write_to_pigo_file()
@@ -316,15 +349,19 @@ class CommandModule:
             Dictionary that contains gimbal commands with pitch and yaw angles named y and z respectively
         """
         if gimbalCommands is None:
-            raise ValueError("gimbalCommands must be a dict and not None.")
+            self.__logger.error("gimbalCommands must be a dict and not None.")
+            return None
         if type(gimbalCommands) is not dict:
-            raise TypeError("gimbalCommands must be a dict and not {}".format(type(gimbalCommands)))
+            self.__logger.error("gimbalCommands must be a dict and not {}.".format(type(gimbalCommands)))
+            return None
         for key in ("z", "y"):
             if key not in gimbalCommands.keys():
-                raise KeyError("gimbalCommands must contain {} key".format(key))
+                self.__logger.error("gimbalCommands must contain {} key.".format(key))
+                return None
         for key in ("z", "y"):
             if type(gimbalCommands[key]) is not float:
-                raise TypeError("gimbalCommands {} key must be a float".format(key))
+                self.__logger.error("gimbalCommands {} key must be a float.".format(key))
+                return None
 
         self.__pigoData.update({"gimbalCommands" : gimbalCommands})
         self.__write_to_pigo_file()
@@ -339,9 +376,11 @@ class CommandModule:
             Boolean containing whether or not to initiate landing sequence
         """
         if beginLanding is None:
-            raise ValueError("beginLanding must be a bool and not None.")
+            self.__logger.error("beginLanding must be a bool and not None.")
+            return None
         if type(beginLanding) is not bool:
-            raise TypeError("beginLanding must be a bool and not {}".format(type(beginLanding)))
+            self.__logger.error("beginLanding must be a bool and not {}.".format(type(beginLanding)))
+            return None
 
         self.__pigoData.update({"beginLanding" : beginLanding})
         self.__write_to_pigo_file()
@@ -356,9 +395,11 @@ class CommandModule:
             Boolean containing whether or not to initiate takeoff sequence
         """
         if beginTakeoff is None:
-            raise ValueError("beginTakeoff must be a bool and not None.")
+            self.__logger.error("beginTakeoff must be a bool and not None.")
+            return None
         if type(beginTakeoff) is not bool:
-            raise TypeError("beginTakeoff must be a bool and not {}".format(type(beginTakeoff)))
+            self.__logger.error("beginTakeoff must be a bool and not {}.".format(type(beginTakeoff)))
+            return None
 
         self.__pigoData.update({"beginTakeoff" : beginTakeoff})
         self.__write_to_pigo_file()
@@ -373,9 +414,11 @@ class CommandModule:
             Boolean containing whether or not to disconnect auto pilot
         """
         if disconnectAutoPilot is None:
-            raise ValueError("disconnectAutopilot must be a bool and not None.")
+            self.__logger.error("disconnectAutopilot must be a bool and not None.")
+            return None
         if type(disconnectAutoPilot) is not bool:
-            raise TypeError("disconnectAutopilot must be a bool and not {}".format(type(disconnectAutoPilot)))
+            self.__logger.error("disconnectAutopilot must be a bool and not {}.".format(type(disconnectAutoPilot)))
+            return None
 
         self.__pigoData.update({"disconnectAutoPilot" : disconnectAutoPilot})
         self.__write_to_pigo_file()

--- a/modules/commandModule/tests/testCases/testReadNullFromPogi.py
+++ b/modules/commandModule/tests/testCases/testReadNullFromPogi.py
@@ -7,7 +7,6 @@ from ...commandModule import CommandModule
 class TestReadingNullFromPOGIFiles(unittest.TestCase):
 
     def setUp(self):
-        self.logger = logging.basicConfig(level=logging.DEBUG, )
         self.pogiData = dict()
         self.pigoFile = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testJSONs", "testPigo.json")
         self.pogiFile = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testJSONs", "testPogi.json")
@@ -23,89 +22,121 @@ class TestReadingNullFromPOGIFiles(unittest.TestCase):
 
     def test_value_error_if_get_error_code_equals_null(self):
         self.__value_instantiate("errorCode", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_error_code()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:errorCode not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_value_error_if_get_altitude_equals_none(self):
         self.__value_instantiate("currentAltitude", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_current_altitude()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:currentAltitude not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_airspeed_equals_none(self):
         self.__value_instantiate("currentAirspeed", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_current_airspeed()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:currentAirspeed not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_is_landed_equals_none(self):
         self.__value_instantiate("isLanded", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_is_landed()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:isLanded not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_camera_equals_none(self):
         self.__value_instantiate("eulerAnglesOfCamera", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:eulerAnglesOfCamera not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_camera_x_equals_none(self):
         euler_camera = {"x": None, "y": 0.0, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfCamera", euler_camera)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:x in eulerAnglesOfCamera is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_camera_y_equals_none(self):
         euler_camera = {"x": 0.0, "y": None, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfCamera", euler_camera)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:y in eulerAnglesOfCamera is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_camera_z_equals_none(self):
         euler_camera = {"x": 0.0, "y": 0.0, "z": None}
         self.__value_instantiate("eulerAnglesOfCamera", euler_camera)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:z in eulerAnglesOfCamera is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_plane_equals_none(self):
         self.__value_instantiate("eulerAnglesOfPlane", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:eulerAnglesOfPlane not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_plane_x_equals_none(self):
         euler_camera = {"x": None, "y": 0.0, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfPlane", euler_camera)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:x in eulerAnglesOfPlane is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_plane_y_equals_none(self):
         euler_camera = {"x": 0.0, "y": None, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfPlane", euler_camera)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:y in eulerAnglesOfPlane is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_euler_plane_z_equals_none(self):
         euler_plane= {"x": 0.0, "y": 0.0, "z": None}
         self.__value_instantiate("eulerAnglesOfPlane", euler_plane)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:z in eulerAnglesOfPlane is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_gps_equals_none(self):
         self.__value_instantiate("gpsCoordinates", None)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates not found in the POGI json file.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_gps_lat_equals_none(self):
         gps = {"latitude": None, "longitude": 2.134, "altitude": 1.234}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:latitude in gpsCoordinates is null.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_get_gps_lng_equals_none(self):
         gps = {"latitude": 1.212, "longitude": None, "altitude": 1.234}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:longitude in gpsCoordinates is null.", ])
+        logging.info(cm.output)
     
     def test_value_error_if_get_gps_alt_equals_none(self):
         gps = {"latitude": 1.212, "longitude": 12.31, "altitude": None}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:altitude in gpsCoordinates is null.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testReadWrongTypeFromPogi.py
+++ b/modules/commandModule/tests/testCases/testReadWrongTypeFromPogi.py
@@ -23,89 +23,121 @@ class TestReadingWrongTypeFromPOGIFiles(unittest.TestCase):
 
     def test_type_error_if_get_error_code_equals_null(self):
         self.__value_instantiate("errorCode", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_error_code()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:errorCode found in POGI file is not an int.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_altitude_equals_wrong_type(self):
         self.__value_instantiate("currentAltitude", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_current_altitude()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:currentAltitude in the POGI file is not an int.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_airspeed_equals_wrong_type(self):
         self.__value_instantiate("currentAirspeed", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_current_airspeed()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:currentAirspeed in the POGI file is not an int.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_is_landed_equals_wrong_type(self):
         self.__value_instantiate("isLanded", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_is_landed()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:isLanded in the POGI file is not an int.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_camera_equals_wrong_type(self):
         self.__value_instantiate("eulerAnglesOfCamera", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:eulerAnglesOfCamera in the POGI file is not a dictionary.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_camera_x_equals_wrong_type(self):
         eulerAnglesOfCamera = {"x": "0", "y": 0.0, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfCamera", eulerAnglesOfCamera)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:x in eulerAnglesOfCamera is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_camera_y_equals_wrong_type(self):
         eulerAnglesOfCamera = {"x": 0.0, "y": "0", "z": 0.0}
         self.__value_instantiate("eulerAnglesOfCamera", eulerAnglesOfCamera)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:y in eulerAnglesOfCamera is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_camera_z_equals_wrong_type(self):
         eulerAnglesOfCamera = {"x": 0.0, "y": 0.0, "z": "0"}
         self.__value_instantiate("eulerAnglesOfCamera", eulerAnglesOfCamera)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_camera()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:z in eulerAnglesOfCamera is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_plane_equals_wrong_type(self):
         self.__value_instantiate("eulerAnglesOfPlane", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:eulerAnglesOfPlane in the POGI file is not a dictionary.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_plane_x_equals_wrong_type(self):
         eulerAnglesOfCamera = {"x": "0", "y": 0.0, "z": 0.0}
         self.__value_instantiate("eulerAnglesOfPlane", eulerAnglesOfCamera)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:x in eulerAnglesOfPlane is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_plane_y_equals_wrong_type(self):
         eulerAnglesOfCamera = {"x": 0.0, "y": "0", "z": 0.0}
         self.__value_instantiate("eulerAnglesOfPlane", eulerAnglesOfCamera)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:y in eulerAnglesOfPlane is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_euler_angles_of_plane_z_equals_wrong_type(self):
         eulerAnglesOfPlane = {"x": 0.0, "y": 0.0, "z": "0"}
         self.__value_instantiate("eulerAnglesOfPlane", eulerAnglesOfPlane)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_euler_angles_of_plane()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:z in eulerAnglesOfPlane is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_gps_equals_wrong_type(self):
         self.__value_instantiate("gpsCoordinates", "0")
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates in the POGI file is not a dictionary.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_gps_latitude_equals_wrong_type(self):
         gps = {"latitude": "blah", "longitude": 12.31, "altitude": 11.23}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:latitude in gpsCoordinates is not a float.", ])
+        logging.info(cm.output)
 
     def test_type_error_if_get_gps_longitude_equals_wrong_type(self):
         gps = {"latitude": 1.212, "longitude": "blah", "altitude": 11.23}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:longitude in gpsCoordinates is not a float.", ])
+        logging.info(cm.output)
     
     def test_value_error_if_get_gps_alt_equals_wrong_type(self):
         gps = {"latitude": 1.212, "longitude": 12.31, "altitude": "blah"}
         self.__value_instantiate("gpsCoordinates", gps)
-        with self.assertRaises(TypeError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.get_gps_coordinates()
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:altitude in gpsCoordinates is not a float.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testWriteMissingGPSCoordinateAttributes.py
+++ b/modules/commandModule/tests/testCases/testWriteMissingGPSCoordinateAttributes.py
@@ -1,6 +1,7 @@
 from ...commandModule import CommandModule
 import unittest
 import os
+import logging
 
 class TestCaseWritingMissingGPSCoordinateAttributes(unittest.TestCase):
     """
@@ -18,15 +19,21 @@ class TestCaseWritingMissingGPSCoordinateAttributes(unittest.TestCase):
 
     def test_key_error_if_set_gps_coordinates_missing_latitude_attribute(self):
         temp = {"longitude":1.234, "altitude":2.312}
-        with self.assertRaises(KeyError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gps_coordinates(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates must contain latitude key.", ])
+        logging.info(cm.output)
 
     def test_key_error_if_set_gps_coordinates_missing_longitude_attribute(self):
         temp = {"latitude":1.234, "altitude":2.312}
-        with self.assertRaises(KeyError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gps_coordinates(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates must contain longitude key.", ])
+        logging.info(cm.output)
 
     def test_key_error_if_set_gps_coordinates_missing_altitude_attribute(self):
         temp = {"longitude":1.234, "latitude":2.312}
-        with self.assertRaises(KeyError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gps_coordinates(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates must contain altitude key.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testWriteMissingGimbalCommandAttributes.py
+++ b/modules/commandModule/tests/testCases/testWriteMissingGimbalCommandAttributes.py
@@ -1,6 +1,7 @@
 from ...commandModule import CommandModule
 import unittest
 import os
+import logging
 
 class TestCaseWritingMissingGimbalCommandAttributes(unittest.TestCase):
     """
@@ -18,10 +19,14 @@ class TestCaseWritingMissingGimbalCommandAttributes(unittest.TestCase):
 
     def test_key_error_if_set_gimbal_commands_missing_yaw_attribute(self):
         temp = {"y":1.231}
-        with self.assertRaises(KeyError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gimbal_commands(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gimbalCommands must contain z key.", ])
+        logging.info(cm.output)
 
     def test_key_error_if_set_gimbal_commands_missing_pitch_attribute(self):
         temp = {"z":1.213}
-        with self.assertRaises(KeyError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gimbal_commands(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gimbalCommands must contain y key.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testWriteMissingGroundCommandAttributes.py
+++ b/modules/commandModule/tests/testCases/testWriteMissingGroundCommandAttributes.py
@@ -1,6 +1,7 @@
 from ...commandModule import CommandModule
 import unittest
 import os
+import logging
 
 class TestCaseWritingMissingGroundCommandAttributes(unittest.TestCase):
     """
@@ -18,10 +19,14 @@ class TestCaseWritingMissingGroundCommandAttributes(unittest.TestCase):
 
     def test_key_error_if_set_ground_commands_missing_heading_attribute(self):
         temp = {"latestDistance":1.234}
-        with self.assertRaises(KeyError):
-            self.commandModule.set_gimbal_commands(temp)
+        with self.assertLogs(level="ERROR") as cm:
+            self.commandModule.set_ground_commands(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:groundCommands must contain heading key.", ])
+        logging.info(cm.output)
 
     def test_key_error_if_set_ground_commands_missing_latest_distance_attribute(self):
         temp = {"heading":1.234}
-        with self.assertRaises(KeyError):
-            self.commandModule.set_gimbal_commands(temp)
+        with self.assertLogs(level="ERROR") as cm:
+            self.commandModule.set_ground_commands(temp)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:groundCommands must contain latestDistance key.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testWriteNullToPigo.py
+++ b/modules/commandModule/tests/testCases/testWriteNullToPigo.py
@@ -1,6 +1,7 @@
 from ...commandModule import CommandModule
 import unittest
 import os
+import logging
 
 class TestCaseWritingNullToPIGOFile(unittest.TestCase):
     """
@@ -22,25 +23,37 @@ class TestCaseWritingNullToPIGOFile(unittest.TestCase):
         open(self.pigoFile, "w").close() # delete file contents before next unit test
 
     def test_value_error_if_set_gps_coords_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gps_coordinates(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not None.", ])
+        logging.info(cm.output)
     
     def test_value_error_if_set_ground_commands_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_ground_commands(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:groundCommands must be a dict and not None.", ])
+        logging.info(cm.output)
     
     def test_value_error_if_set_gimbal_commands_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_gimbal_commands(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not None.", ])
+        logging.info(cm.output)
     
     def test_value_error_if_set_begin_landing_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_begin_landing(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:beginLanding must be a bool and not None.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_set_begin_takeoff_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_begin_takeoff(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not None.", ])
+        logging.info(cm.output)
 
     def test_value_error_if_set_disconnect_autopilot_to_null(self):
-        with self.assertRaises(ValueError):
+        with self.assertLogs(level="ERROR") as cm:
             self.commandModule.set_disconnect_autopilot(None)
+        self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not None.", ])
+        logging.info(cm.output)

--- a/modules/commandModule/tests/testCases/testWriteWrongTypeToPigo.py
+++ b/modules/commandModule/tests/testCases/testWriteWrongTypeToPigo.py
@@ -1,6 +1,7 @@
 from ...commandModule import CommandModule
 import unittest
 import os
+import logging
 
 class TestCaseWritingWrongTypeToPIGOFile(unittest.TestCase):
     """
@@ -40,35 +41,47 @@ class TestCaseWritingWrongTypeToPIGOFile(unittest.TestCase):
     def test_type_error_if_set_gps_coords_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not dict:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_gps_coordinates(test)
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not {}.".format(type(test)), ])
+                logging.info(cm.output)
     
     def test_type_error_if_set_ground_commands_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not dict:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_ground_commands(test)
-    
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:groundCommands must be a dict and not {}.".format(type(test)), ])
+                logging.info(cm.output)
+
     def test_type_error_if_set_gimbal_commands_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not dict:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_gimbal_commands(test)
-    
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not {}.".format(type(test)), ])
+                logging.info(cm.output)
+
     def test_type_error_if_set_begin_landing_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not bool:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_begin_landing(test)
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:beginLanding must be a bool and not {}.".format(type(test)), ])
+                logging.info(cm.output)
 
     def test_type_error_if_set_begin_takeoff_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not bool:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_begin_takeoff(test)
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not {}.".format(type(test)), ])
+                logging.info(cm.output)
 
     def test_type_error_if_set_disconnect_autopilot_to_wrong_type(self):
         for test in self.testData:
             if type(test) is not bool:
-                with self.subTest(passed_data=test), self.assertRaises(TypeError):
+                with self.subTest(passed_data=test), self.assertLogs(level="ERROR") as cm:
                     self.commandModule.set_disconnect_autopilot(test)
+                self.assertEqual(cm.output, ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not {}.".format(type(test)), ])
+                logging.info(cm.output)

--- a/modules/commandModule/tests/testLogs/12.27.34_2021_04_04
+++ b/modules/commandModule/tests/testLogs/12.27.34_2021_04_04
@@ -75,6 +75,6 @@ test_type_error_if_set_gps_coords_to_wrong_type (commandModule.tests.testCases.t
 test_type_error_if_set_ground_commands_to_wrong_type (commandModule.tests.testCases.testWriteWrongTypeToPigo.TestCaseWritingWrongTypeToPIGOFile) ... ok
 
 ----------------------------------------------------------------------
-Ran 75 tests in 0.114s
+Ran 75 tests in 0.159s
 
 OK

--- a/modules/commandModule/tests/testLogs/debug.log
+++ b/modules/commandModule/tests/testLogs/debug.log
@@ -1,204 +1,199 @@
-20:22:22,351 filelock DEBUG Attempting to acquire lock 4575739424 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,352 filelock INFO Lock 4575739424 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,352 filelock DEBUG Attempting to release lock 4575739424 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,352 filelock INFO Lock 4575739424 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,353 filelock DEBUG Attempting to acquire lock 4575739568 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,353 filelock INFO Lock 4575739568 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,353 filelock DEBUG Attempting to release lock 4575739568 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,353 filelock INFO Lock 4575739568 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,354 filelock DEBUG Attempting to acquire lock 4575739472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,354 filelock INFO Lock 4575739472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,354 filelock DEBUG Attempting to release lock 4575739472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,354 filelock INFO Lock 4575739472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,355 filelock DEBUG Attempting to acquire lock 4575739328 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,355 filelock INFO Lock 4575739328 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,355 filelock DEBUG Attempting to release lock 4575739328 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,356 filelock INFO Lock 4575739328 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,356 filelock DEBUG Attempting to acquire lock 4575267520 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,356 filelock INFO Lock 4575267520 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,357 filelock DEBUG Attempting to release lock 4575267520 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,357 filelock INFO Lock 4575267520 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,357 filelock DEBUG Attempting to acquire lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,358 filelock INFO Lock 4575267616 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,358 filelock DEBUG Attempting to release lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,358 filelock INFO Lock 4575267616 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,359 filelock DEBUG Attempting to acquire lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,359 filelock INFO Lock 4575267472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,359 filelock DEBUG Attempting to release lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,359 filelock INFO Lock 4575267472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,360 filelock DEBUG Attempting to acquire lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,360 filelock INFO Lock 4575267664 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,361 filelock DEBUG Attempting to release lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,361 filelock INFO Lock 4575267664 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,361 filelock DEBUG Attempting to acquire lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,362 filelock INFO Lock 4575267664 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,362 filelock DEBUG Attempting to release lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,362 filelock INFO Lock 4575267664 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,363 filelock DEBUG Attempting to acquire lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,363 filelock INFO Lock 4575268144 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,363 filelock DEBUG Attempting to release lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,363 filelock INFO Lock 4575268144 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,364 filelock DEBUG Attempting to acquire lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,364 filelock INFO Lock 4575267472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,364 filelock DEBUG Attempting to release lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,364 filelock INFO Lock 4575267472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,365 filelock DEBUG Attempting to acquire lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,365 filelock INFO Lock 4575268144 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,366 filelock DEBUG Attempting to release lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,366 filelock INFO Lock 4575268144 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,367 filelock DEBUG Attempting to acquire lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,368 filelock INFO Lock 4575267616 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,368 filelock DEBUG Attempting to release lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,368 filelock INFO Lock 4575267616 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,370 filelock DEBUG Attempting to acquire lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,370 filelock INFO Lock 4575267616 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,371 filelock DEBUG Attempting to release lock 4575267616 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,371 filelock INFO Lock 4575267616 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,373 filelock DEBUG Attempting to acquire lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,373 filelock INFO Lock 4575267472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,373 filelock DEBUG Attempting to release lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,373 filelock INFO Lock 4575267472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,375 filelock DEBUG Attempting to acquire lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,375 filelock INFO Lock 4575268144 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,376 filelock DEBUG Attempting to release lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,376 filelock INFO Lock 4575268144 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,378 filelock DEBUG Attempting to acquire lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,378 filelock INFO Lock 4575266272 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,378 filelock DEBUG Attempting to release lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,378 filelock INFO Lock 4575266272 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,380 filelock DEBUG Attempting to acquire lock 4567666800 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,381 filelock INFO Lock 4567666800 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,381 filelock DEBUG Attempting to release lock 4567666800 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,381 filelock INFO Lock 4567666800 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,383 filelock DEBUG Attempting to acquire lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,384 filelock INFO Lock 4575266272 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,384 filelock DEBUG Attempting to release lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,384 filelock INFO Lock 4575266272 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,386 filelock DEBUG Attempting to acquire lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,386 filelock INFO Lock 4575267664 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,386 filelock DEBUG Attempting to release lock 4575267664 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,386 filelock INFO Lock 4575267664 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,388 filelock DEBUG Attempting to acquire lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,388 filelock INFO Lock 4575268144 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,389 filelock DEBUG Attempting to release lock 4575268144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,389 filelock INFO Lock 4575268144 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,391 filelock DEBUG Attempting to acquire lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,391 filelock INFO Lock 4575267472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,391 filelock DEBUG Attempting to release lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,391 filelock INFO Lock 4575267472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,393 filelock DEBUG Attempting to acquire lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,393 filelock INFO Lock 4575266272 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,394 filelock DEBUG Attempting to release lock 4575266272 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,394 filelock INFO Lock 4575266272 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,396 filelock DEBUG Attempting to acquire lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,396 filelock INFO Lock 4575267472 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,396 filelock DEBUG Attempting to release lock 4575267472 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,396 filelock INFO Lock 4575267472 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,398 filelock DEBUG Attempting to acquire lock 4574354544 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,398 filelock INFO Lock 4574354544 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,399 filelock DEBUG Attempting to release lock 4574354544 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,399 filelock INFO Lock 4574354544 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,400 filelock DEBUG Attempting to acquire lock 4574354544 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,400 filelock INFO Lock 4574354544 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,401 filelock DEBUG Attempting to release lock 4574354544 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,401 filelock INFO Lock 4574354544 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,402 filelock DEBUG Attempting to acquire lock 4574355216 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,403 filelock INFO Lock 4574355216 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,403 filelock DEBUG Attempting to release lock 4574355216 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,403 filelock INFO Lock 4574355216 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,404 filelock DEBUG Attempting to acquire lock 4575646144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,404 filelock INFO Lock 4575646144 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,404 filelock DEBUG Attempting to release lock 4575646144 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,404 filelock INFO Lock 4575646144 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,405 filelock DEBUG Attempting to acquire lock 4574355216 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,405 filelock INFO Lock 4574355216 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,406 filelock DEBUG Attempting to release lock 4574355216 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,406 filelock INFO Lock 4574355216 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,407 filelock DEBUG Attempting to acquire lock 4575646096 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,407 filelock INFO Lock 4575646096 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,407 filelock DEBUG Attempting to release lock 4575646096 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,407 filelock INFO Lock 4575646096 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,408 filelock DEBUG Attempting to acquire lock 4575646288 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,408 filelock INFO Lock 4575646288 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,408 filelock DEBUG Attempting to release lock 4575646288 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,408 filelock INFO Lock 4575646288 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,409 filelock DEBUG Attempting to acquire lock 4575646288 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,409 filelock INFO Lock 4575646288 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,409 filelock DEBUG Attempting to release lock 4575646288 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,410 filelock INFO Lock 4575646288 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,410 filelock DEBUG Attempting to acquire lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,411 filelock INFO Lock 4575646240 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,411 filelock DEBUG Attempting to release lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,411 filelock INFO Lock 4575646240 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,412 filelock DEBUG Attempting to acquire lock 4575646432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,412 filelock INFO Lock 4575646432 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,412 filelock DEBUG Attempting to release lock 4575646432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,412 filelock INFO Lock 4575646432 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,413 filelock DEBUG Attempting to acquire lock 4575646192 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,413 filelock INFO Lock 4575646192 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,414 filelock DEBUG Attempting to release lock 4575646192 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,414 filelock INFO Lock 4575646192 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,415 filelock DEBUG Attempting to acquire lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,415 filelock INFO Lock 4575646240 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,415 filelock DEBUG Attempting to release lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,415 filelock INFO Lock 4575646240 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,417 filelock DEBUG Attempting to acquire lock 4575646432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,417 filelock INFO Lock 4575646432 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,418 filelock DEBUG Attempting to release lock 4575646432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,418 filelock INFO Lock 4575646432 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,419 filelock DEBUG Attempting to acquire lock 4575646192 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,419 filelock INFO Lock 4575646192 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,420 filelock DEBUG Attempting to release lock 4575646192 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,420 filelock INFO Lock 4575646192 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,421 filelock DEBUG Attempting to acquire lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,422 filelock INFO Lock 4575646240 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,422 filelock DEBUG Attempting to release lock 4575646240 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,422 filelock INFO Lock 4575646240 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
-20:22:22,432 filelock DEBUG Attempting to acquire lock 4575542432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,432 filelock INFO Lock 4575542432 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,433 filelock DEBUG Attempting to release lock 4575542432 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,433 filelock INFO Lock 4575542432 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,434 filelock DEBUG Attempting to acquire lock 4575678960 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,435 filelock INFO Lock 4575678960 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,435 filelock DEBUG Attempting to release lock 4575678960 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,435 filelock INFO Lock 4575678960 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,437 filelock DEBUG Attempting to acquire lock 4575542480 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,437 filelock INFO Lock 4575542480 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,438 filelock DEBUG Attempting to release lock 4575542480 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,438 filelock INFO Lock 4575542480 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,439 filelock DEBUG Attempting to acquire lock 4575649504 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,439 filelock INFO Lock 4575649504 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,440 filelock DEBUG Attempting to release lock 4575649504 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,440 filelock INFO Lock 4575649504 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,441 filelock DEBUG Attempting to acquire lock 4575649504 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,441 filelock INFO Lock 4575649504 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,442 filelock DEBUG Attempting to release lock 4575649504 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,442 filelock INFO Lock 4575649504 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,443 filelock DEBUG Attempting to acquire lock 4575679776 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,443 filelock INFO Lock 4575679776 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,444 filelock DEBUG Attempting to release lock 4575679776 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,444 filelock INFO Lock 4575679776 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,454 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,455 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,455 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,455 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,455 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,455 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,456 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,457 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,458 filelock DEBUG Attempting to acquire lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,458 filelock INFO Lock 4575681024 acquired on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,458 filelock DEBUG Attempting to release lock 4575681024 on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
-20:22:22,458 filelock INFO Lock 4575681024 released on /Users/ksisjaya/Desktop/computer_vision_python/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,703 root INFO ['ERROR:commandModule.commandModule:currentAirspeed not found in the POGI json file.']
+12:27:34,704 root INFO ['ERROR:commandModule.commandModule:errorCode not found in the POGI json file.']
+12:27:34,705 root INFO ['ERROR:commandModule.commandModule:eulerAnglesOfCamera not found in the POGI json file.']
+12:27:34,706 root INFO ['ERROR:commandModule.commandModule:x in eulerAnglesOfCamera is null.']
+12:27:34,707 root INFO ['ERROR:commandModule.commandModule:y in eulerAnglesOfCamera is null.']
+12:27:34,708 root INFO ['ERROR:commandModule.commandModule:z in eulerAnglesOfCamera is null.']
+12:27:34,709 root INFO ['ERROR:commandModule.commandModule:eulerAnglesOfPlane not found in the POGI json file.']
+12:27:34,710 root INFO ['ERROR:commandModule.commandModule:x in eulerAnglesOfPlane is null.']
+12:27:34,713 root INFO ['ERROR:commandModule.commandModule:y in eulerAnglesOfPlane is null.']
+12:27:34,715 root INFO ['ERROR:commandModule.commandModule:z in eulerAnglesOfPlane is null.']
+12:27:34,717 root INFO ['ERROR:commandModule.commandModule:altitude in gpsCoordinates is null.']
+12:27:34,719 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates not found in the POGI json file.']
+12:27:34,721 root INFO ['ERROR:commandModule.commandModule:latitude in gpsCoordinates is null.']
+12:27:34,723 root INFO ['ERROR:commandModule.commandModule:longitude in gpsCoordinates is null.']
+12:27:34,726 root INFO ['ERROR:commandModule.commandModule:isLanded not found in the POGI json file.']
+12:27:34,728 root INFO ['ERROR:commandModule.commandModule:currentAltitude not found in the POGI json file.']
+12:27:34,731 filelock DEBUG Attempting to acquire lock 4369608272 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,731 filelock INFO Lock 4369608272 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,731 filelock DEBUG Attempting to release lock 4369608272 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,731 filelock INFO Lock 4369608272 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,732 filelock DEBUG Attempting to acquire lock 4369608464 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,733 filelock INFO Lock 4369608464 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,733 filelock DEBUG Attempting to release lock 4369608464 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,733 filelock INFO Lock 4369608464 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,734 filelock DEBUG Attempting to acquire lock 4369608368 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,734 filelock INFO Lock 4369608368 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,734 filelock DEBUG Attempting to release lock 4369608368 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,734 filelock INFO Lock 4369608368 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,735 filelock DEBUG Attempting to acquire lock 4369608176 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,735 filelock INFO Lock 4369608176 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,735 filelock DEBUG Attempting to release lock 4369608176 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,735 filelock INFO Lock 4369608176 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,736 filelock DEBUG Attempting to acquire lock 4369608272 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,736 filelock INFO Lock 4369608272 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,736 filelock DEBUG Attempting to release lock 4369608272 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,736 filelock INFO Lock 4369608272 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,737 filelock DEBUG Attempting to acquire lock 4369608512 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,738 filelock INFO Lock 4369608512 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,738 filelock DEBUG Attempting to release lock 4369608512 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,738 filelock INFO Lock 4369608512 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,739 filelock DEBUG Attempting to acquire lock 4369608368 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,739 filelock INFO Lock 4369608368 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,739 filelock DEBUG Attempting to release lock 4369608368 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,739 filelock INFO Lock 4369608368 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPogi.json.lock
+12:27:34,741 root INFO ['ERROR:commandModule.commandModule:currentAirspeed in the POGI file is not an int.']
+12:27:34,742 root INFO ['ERROR:commandModule.commandModule:currentAltitude in the POGI file is not an int.']
+12:27:34,744 root INFO ['ERROR:commandModule.commandModule:errorCode found in POGI file is not an int.']
+12:27:34,748 root INFO ['ERROR:commandModule.commandModule:eulerAnglesOfCamera in the POGI file is not a dictionary.']
+12:27:34,749 root INFO ['ERROR:commandModule.commandModule:x in eulerAnglesOfCamera is not a float.']
+12:27:34,751 root INFO ['ERROR:commandModule.commandModule:y in eulerAnglesOfCamera is not a float.']
+12:27:34,752 root INFO ['ERROR:commandModule.commandModule:z in eulerAnglesOfCamera is not a float.']
+12:27:34,754 root INFO ['ERROR:commandModule.commandModule:eulerAnglesOfPlane in the POGI file is not a dictionary.']
+12:27:34,756 root INFO ['ERROR:commandModule.commandModule:x in eulerAnglesOfPlane is not a float.']
+12:27:34,758 root INFO ['ERROR:commandModule.commandModule:y in eulerAnglesOfPlane is not a float.']
+12:27:34,760 root INFO ['ERROR:commandModule.commandModule:z in eulerAnglesOfPlane is not a float.']
+12:27:34,762 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates in the POGI file is not a dictionary.']
+12:27:34,765 root INFO ['ERROR:commandModule.commandModule:latitude in gpsCoordinates is not a float.']
+12:27:34,768 root INFO ['ERROR:commandModule.commandModule:longitude in gpsCoordinates is not a float.']
+12:27:34,770 root INFO ['ERROR:commandModule.commandModule:isLanded in the POGI file is not an int.']
+12:27:34,772 root INFO ['ERROR:commandModule.commandModule:altitude in gpsCoordinates is not a float.']
+12:27:34,785 filelock DEBUG Attempting to acquire lock 4361822320 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,785 filelock INFO Lock 4361822320 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,786 filelock DEBUG Attempting to release lock 4361822320 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,786 filelock INFO Lock 4361822320 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,787 filelock DEBUG Attempting to acquire lock 4370083904 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,787 filelock INFO Lock 4370083904 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,787 filelock DEBUG Attempting to release lock 4370083904 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,788 filelock INFO Lock 4370083904 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,788 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,789 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,789 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,789 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,790 filelock DEBUG Attempting to acquire lock 4370085200 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,790 filelock INFO Lock 4370085200 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,790 filelock DEBUG Attempting to release lock 4370085200 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,790 filelock INFO Lock 4370085200 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,791 filelock DEBUG Attempting to acquire lock 4370084192 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,791 filelock INFO Lock 4370084192 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,791 filelock DEBUG Attempting to release lock 4370084192 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,791 filelock INFO Lock 4370084192 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,792 filelock DEBUG Attempting to acquire lock 4370085248 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,792 filelock INFO Lock 4370085248 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,793 filelock DEBUG Attempting to release lock 4370085248 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,793 filelock INFO Lock 4370085248 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,795 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates must contain altitude key.']
+12:27:34,797 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates must contain latitude key.']
+12:27:34,798 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates must contain longitude key.']
+12:27:34,799 root INFO ['ERROR:commandModule.commandModule:gimbalCommands must contain y key.']
+12:27:34,801 root INFO ['ERROR:commandModule.commandModule:gimbalCommands must contain z key.']
+12:27:34,802 root INFO ['ERROR:commandModule.commandModule:groundCommands must contain heading key.']
+12:27:34,803 root INFO ['ERROR:commandModule.commandModule:groundCommands must contain latestDistance key.']
+12:27:34,804 root INFO ['ERROR:commandModule.commandModule:beginLanding must be a bool and not None.']
+12:27:34,804 root INFO ['ERROR:commandModule.commandModule:beginTakeoff must be a bool and not None.']
+12:27:34,805 root INFO ['ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not None.']
+12:27:34,805 root INFO ['ERROR:commandModule.commandModule:gimbalCommands must be a dict and not None.']
+12:27:34,806 root INFO ['ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not None.']
+12:27:34,807 root INFO ['ERROR:commandModule.commandModule:groundCommands must be a dict and not None.']
+12:27:34,807 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,807 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,808 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,808 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,808 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,808 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,809 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,809 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,809 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,809 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,810 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,810 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,811 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,811 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,812 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,812 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,813 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,813 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,813 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,814 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,814 filelock DEBUG Attempting to acquire lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,814 filelock INFO Lock 4368506064 acquired on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,815 filelock DEBUG Attempting to release lock 4368506064 on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,815 filelock INFO Lock 4368506064 released on /Users/ksisjaya/Desktop/kevin_uwarg/modules/commandModule/tests/testCases/../testJSONs/testPigo.json.lock
+12:27:34,816 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'str'>."]
+12:27:34,819 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'int'>."]
+12:27:34,820 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'float'>."]
+12:27:34,820 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'complex'>."]
+12:27:34,821 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'list'>."]
+12:27:34,821 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'tuple'>."]
+12:27:34,821 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'range'>."]
+12:27:34,822 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'dict'>."]
+12:27:34,822 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'set'>."]
+12:27:34,822 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'frozenset'>."]
+12:27:34,823 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'bytes'>."]
+12:27:34,823 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'bytearray'>."]
+12:27:34,823 root INFO ["ERROR:commandModule.commandModule:beginLanding must be a bool and not <class 'memoryview'>."]
+12:27:34,825 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'str'>."]
+12:27:34,825 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'int'>."]
+12:27:34,825 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'float'>."]
+12:27:34,826 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'complex'>."]
+12:27:34,826 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'list'>."]
+12:27:34,827 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'tuple'>."]
+12:27:34,827 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'range'>."]
+12:27:34,827 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'dict'>."]
+12:27:34,828 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'set'>."]
+12:27:34,828 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'frozenset'>."]
+12:27:34,828 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'bytes'>."]
+12:27:34,828 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'bytearray'>."]
+12:27:34,829 root INFO ["ERROR:commandModule.commandModule:beginTakeoff must be a bool and not <class 'memoryview'>."]
+12:27:34,835 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'str'>."]
+12:27:34,836 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'int'>."]
+12:27:34,837 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'float'>."]
+12:27:34,837 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'complex'>."]
+12:27:34,837 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'list'>."]
+12:27:34,837 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'tuple'>."]
+12:27:34,838 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'range'>."]
+12:27:34,838 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'dict'>."]
+12:27:34,838 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'set'>."]
+12:27:34,838 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'frozenset'>."]
+12:27:34,839 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'bytes'>."]
+12:27:34,839 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'bytearray'>."]
+12:27:34,839 root INFO ["ERROR:commandModule.commandModule:disconnectAutopilot must be a bool and not <class 'memoryview'>."]
+12:27:34,840 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'str'>."]
+12:27:34,840 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'int'>."]
+12:27:34,840 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'float'>."]
+12:27:34,841 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'complex'>."]
+12:27:34,841 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'list'>."]
+12:27:34,841 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'tuple'>."]
+12:27:34,841 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'range'>."]
+12:27:34,842 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'set'>."]
+12:27:34,842 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'frozenset'>."]
+12:27:34,842 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'bool'>."]
+12:27:34,843 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'bytes'>."]
+12:27:34,843 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'bytearray'>."]
+12:27:34,843 root INFO ["ERROR:commandModule.commandModule:gimbalCommands must be a dict and not <class 'memoryview'>."]
+12:27:34,850 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'str'>."]
+12:27:34,850 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'int'>."]
+12:27:34,852 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'float'>."]
+12:27:34,852 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'complex'>."]
+12:27:34,852 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'list'>."]
+12:27:34,853 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'tuple'>."]
+12:27:34,853 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'range'>."]
+12:27:34,854 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'set'>."]
+12:27:34,854 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'frozenset'>."]
+12:27:34,854 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'bool'>."]
+12:27:34,854 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'bytes'>."]
+12:27:34,855 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'bytearray'>."]
+12:27:34,855 root INFO ["ERROR:commandModule.commandModule:gpsCoordinates must be a dict and not <class 'memoryview'>."]
+12:27:34,856 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'str'>."]
+12:27:34,857 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'int'>."]
+12:27:34,857 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'float'>."]
+12:27:34,857 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'complex'>."]
+12:27:34,858 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'list'>."]
+12:27:34,858 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'tuple'>."]
+12:27:34,858 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'range'>."]
+12:27:34,858 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'set'>."]
+12:27:34,859 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'frozenset'>."]
+12:27:34,859 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'bool'>."]
+12:27:34,859 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'bytes'>."]
+12:27:34,860 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'bytearray'>."]
+12:27:34,860 root INFO ["ERROR:commandModule.commandModule:groundCommands must be a dict and not <class 'memoryview'>."]


### PR DESCRIPTION
- Change exception handling to logger instead
- **_Return NoneType from command module to indicate an error has occurred_**
- Change to modular logger
- Update test cases to check for logger message
- Update test and debug log
- Allow for logging in test cases to log to debug.log file