### PR TITLE
DeckLink

### DIFF
--- a/modules/decklinksrc/decklinkSrcWorker.py
+++ b/modules/decklinksrc/decklinkSrcWorker.py
@@ -5,9 +5,17 @@ def decklinkSrcWorker(pause, exitRequest, pipelineOut):
     print("Start decklinksrc")
     decklinkSrc = DeckLinkSRC()
 
+    # i = 0  # Debugging
     while True:
+        # Debugging
+        # i += 1
+        # if i > 300:
+        #     decklinkSrc.stop()
+        #     return
+
         # Kill process if exit is requested
         if not exitRequest.empty():
+            decklinkSrc.stop()
             return
 
         pause.acquire()
@@ -16,6 +24,10 @@ def decklinkSrcWorker(pause, exitRequest, pipelineOut):
         curr_frame = decklinkSrc.grab()
         if curr_frame is None:
             continue
+
+        # Debugging
+        # cv2.imshow('VideoStream', curr_frame)
+        # cv2.waitKey(1)
 
         pipelineOut.put(curr_frame)
 

--- a/modules/decklinksrc/decklinksrc.py
+++ b/modules/decklinksrc/decklinksrc.py
@@ -36,6 +36,14 @@ class DeckLinkSRC:
         Initializes DeckLink video stream
         """
         self.__currentFrame = None
+        self.capture = None
+        self.start()
+
+    def start(self):
+        """
+        Logic for (re)starting video stream
+        """
+        self.__currentFrame = None
         self.capture = cv2.VideoCapture(0)  # Starts capture on initialization of object
 
     def stop(self):
@@ -49,12 +57,13 @@ class DeckLinkSRC:
         """
         Logic for grabbing single frame from DeckLink
         """
-        self.__currentFrame = self.capture.read()
+        success, self.__currentFrame = self.capture.read()
         return self.__currentFrame
 
     def recordVideo(self, filename, xdim, ydim):
         """
         Logic for 
+        UNTESTED, use OBS to record
 
         Parameters
         ----------

--- a/modules/decklinksrc/localTest.py
+++ b/modules/decklinksrc/localTest.py
@@ -1,0 +1,38 @@
+import time
+import multiprocessing as mp
+import decklinkSrcWorker
+import cv2
+
+if __name__ = "__main__":
+
+    pause = mp.Lock()
+    exitRequest = mp.Queue()
+    imagePipeline = mp.Queue()
+
+    # Single-process mode - uncomment the i variable in the worker
+    # decklinkSrcWorker.decklinkSrcWorker(pause, exitRequest, imagePipeline)
+
+    # Multiprocess mode
+    # """
+    p = mp.Process(target=decklinkSrcWorker.decklinkSrcWorker,
+                   args=(pause, exitRequest, imagePipeline,))
+    p.start()
+
+    time.sleep(3)
+
+    exitRequest.put(True)
+    # """
+    print("Queue contents:")
+    j = 0
+    while (True):
+        try:
+            # A guaranteed delay is necessary, otherwise this loop will collide with itself!
+            # I'll investigate how short this can be.
+            time.sleep(0.1)
+            frame = imagePipeline.get_nowait()
+            print(frame)
+            j += 1
+        except:
+            break
+
+    print("Done! " + str(j))


### PR DESCRIPTION
To use OBS, stream it to URL (rdp, rtsp, etc.), Change `cv2.VideoCapture()` accept the URL string as input. Source: https://stackoverflow.com/questions/49978705/access-ip-camera-in-python-opencv