### PR TITLE
Fixed calculation for centre of bounding box

### DIFF
--- a/modules/targetAcquisition/targetAcquisition.py
+++ b/modules/targetAcquisition/targetAcquisition.py
@@ -94,8 +94,8 @@ class TargetAcquisition:
         
         # Find centre of bounding box
         for i in range(1, len(self.bbox)):
-            x = self.bbox[i][0][0] + self.bbox[i][1][0]
-            y = self.bbox[i][0][1] + self.bbox[i][1][1]
+            x = self.bbox[i][0][0] + self.bbox[i][1][0] // 2
+            y = self.bbox[i][0][1] + self.bbox[i][1][1] // 2
             self.coordinates.append((x, y))
     
         return True, (self.coordinates, self.telemetryData)


### PR DESCRIPTION
Why:
- Our previous formula for calculating the centre of a bounding box was not really finding the centre

What:
- Divided the previous result by 2 to find the actual centre of the bbox 