### PR TITLE
refactored get_non_collinear_points()

### DIFF
--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -214,6 +214,7 @@ class Geolocation:
         self.__logger.debug("geolocation/get_non_collinear_points: Started")
 
         NUM_POINTS_NEEDED = 4
+        indexes = []
 
         # If there aren't four points, return the empty array
         if len(coordinatesArray) < NUM_POINTS_NEEDED:
@@ -231,20 +232,38 @@ class Geolocation:
             for j in range(0, NUM_POINTS_NEEDED):
                 points[j] = coordinatesArray[(i + j) % len(coordinatesArray)]
 
-            # Check collinearity of all possible combinations
             areNotFourCollinear = True
-            for i in range(0, NUM_POINTS_NEEDED):
-                areNotFourCollinear &= not self.__are_three_points_collinear(points[i],
-                                                                             points[(i + 1) % NUM_POINTS_NEEDED],
-                                                                             points[(i + 2) % NUM_POINTS_NEEDED])
+            index0 = None
+            index1 = None
+            index2 = None
+            index3 = None
+
+            # Check collinearity of all possible combinations
+            for k in range(0, NUM_POINTS_NEEDED):
+                areNotFourCollinear &= not self.__are_three_points_collinear(points[k],
+                                                                             points[(k + 1) % NUM_POINTS_NEEDED],
+                                                                             points[(k + 2) % NUM_POINTS_NEEDED])
+                # Store indexes of current iteration
+                index0 = k
+                index1 = (k + 1) % NUM_POINTS_NEEDED
+                index2 = (k + 2) % NUM_POINTS_NEEDED
+                index3 = (k + 3) % NUM_POINTS_NEEDED
+
+                # If points are colinear, stop looping
+                if (not areNotFourCollinear):
+                    break
 
             # If all four points are non-collinear, return this combination of points
             if areNotFourCollinear:
                 self.__logger.debug("geolocation/get_non_collinear_points: Returned " + str(points))
-                return points
+                indexes = [index0, index1, index2, index3]
+
+                # Sort and return the indexes in ascending order
+                indexes.sort()
+                return indexes
         
         self.__logger.debug("geolocation/get_non_collinear_points: Returned np.empty(shape=(0,2))")
-        return np.empty(shape=(0, 2))
+        return indexes
 
     def calculate_pixel_to_geo_mapping(self):
         """
@@ -585,10 +604,24 @@ class Geolocation:
         if len(point_pairs) < 4:
             return False, None
 
-        non_collinear_points = self.get_non_collinear_points(point_pairs)
+        # Slice point_pairs to shape (n, 2) for input of get_non_collinear_points
+        points = point_pairs[:,1]
+
+        # Get the 4 non-collinear indexes of the array above
+        indexes = self.get_non_collinear_points(points)
+
         # If insufficient point pairs, exit this run and try again
-        if len(non_collinear_points) < 4:
+        if len(indexes) < 4:
             return False, None
+
+        non_collinear_points = np.empty(shape=(0, 2, 2))
+        # Create a subset of the (n, 2, 2) array above using the array of indexes
+        for i in len(indexes):
+            for j in len(point_pairs):
+                if i == j:
+                    non_collinear_points = np.concatenate((non_collinear_points, point_pairs[j]))
+                    # non_collinear_points only stores the 4 non-collinear point pairs
+                    # indicated by the indexes array
 
         self.__pixelToGeoPairs = non_collinear_points
         tranformation_matrix = self.calculate_pixel_to_geo_mapping()

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -243,7 +243,7 @@ class Geolocation:
                 indexes[0] = k
                 indexes[1] = (k + 1) % NUM_POINTS_NEEDED
                 indexes[2] = (k + 2) % NUM_POINTS_NEEDED
-                indexes[3] = (k + 3) % NUM_POINTS_NEEDED #err0r?
+                indexes[3] = (k + 3) % NUM_POINTS_NEEDED
 
                 # If points are collinear, stop looping
                 if (areNotFourCollinear == False):

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -619,7 +619,7 @@ class Geolocation:
         for i in range(0, len(indexes)):
             for j in range (0, len(point_pairs)):
                 if i == j:
-                    non_collinear_points = np.concatenate((non_collinear_points, point_pairs[j]))
+                    non_collinear_points = np.concatenate((non_collinear_points, [point_pairs[j]]))
                     # non_collinear_points only stores the 4 non-collinear point pairs
                     # indicated by the indexes array
 

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -214,7 +214,7 @@ class Geolocation:
         self.__logger.debug("geolocation/get_non_collinear_points: Started")
 
         NUM_POINTS_NEEDED = 4
-        indexes = [0, 0, 0, 0] #this or np.empty?
+        indexes = np.empty(shape=(NUM_POINTS_NEEDED))
 
         # If there aren't four points, return the empty array
         if len(coordinatesArray) < NUM_POINTS_NEEDED:
@@ -240,17 +240,17 @@ class Geolocation:
                                                                              points[(k + 1) % NUM_POINTS_NEEDED],
                                                                              points[(k + 2) % NUM_POINTS_NEEDED])
                 # Store indexes of current iteration
-                indexes[0] = k
-                indexes[1] = (k + 1) % NUM_POINTS_NEEDED
-                indexes[2] = (k + 2) % NUM_POINTS_NEEDED
-                indexes[3] = (k + 3) % NUM_POINTS_NEEDED
+                indexes[0] = (i)
+                indexes[1] = ((i + 1) % NUM_POINTS_NEEDED)
+                indexes[2] = ((i + 2) % NUM_POINTS_NEEDED)
+                indexes[3] = ((i + 3) % NUM_POINTS_NEEDED)
 
                 # If points are collinear, stop looping
                 if (areNotFourCollinear == False):
                     break
 
             # If all four points are non-collinear, return this combination of points
-            if areNotFourCollinear == True:
+            if areNotFourCollinear:
                 self.__logger.debug("geolocation/get_non_collinear_points: Returned " + str(points))
 
                 # Sort and return the indexes in ascending order
@@ -258,7 +258,7 @@ class Geolocation:
                 return indexes
         
         self.__logger.debug("geolocation/get_non_collinear_points: Returned np.empty(shape=(0,2))")
-        return []
+        return np.empty(0)
 
     def calculate_pixel_to_geo_mapping(self):
         """

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -231,6 +231,7 @@ class Geolocation:
             # testing every single combination.
             for j in range(0, NUM_POINTS_NEEDED):
                 points[j] = coordinatesArray[(i + j) % len(coordinatesArray)]
+                indexes[j] = ((i + j) % len(coordinatesArray))
 
             areNotFourCollinear = True
 
@@ -239,11 +240,6 @@ class Geolocation:
                 areNotFourCollinear &= not self.__are_three_points_collinear(points[k],
                                                                              points[(k + 1) % NUM_POINTS_NEEDED],
                                                                              points[(k + 2) % NUM_POINTS_NEEDED])
-                # Store indexes of current iteration
-                indexes[0] = (i)
-                indexes[1] = ((i + 1) % len(coordinatesArray))
-                indexes[2] = ((i + 2) % len(coordinatesArray))
-                indexes[3] = ((i + 3) % len(coordinatesArray))
 
                 # If points are collinear, stop looping
                 if (areNotFourCollinear == False):
@@ -609,10 +605,8 @@ class Geolocation:
         if len(indexes) < 4:
             return False, None
 
-        non_collinear_points = np.array(indexes)
-
         # Create a subset of the (n, 2, 2) array above using the array of indexes
-        non_collinear_points = [point_pairs[i] for i in indexes]
+        non_collinear_points = (point_pairs[indexes])
         # non_collinear_points only stores the 4 non-collinear point pairs
         # indicated by the indexes array
 

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -616,8 +616,8 @@ class Geolocation:
 
         non_collinear_points = np.empty(shape=(0, 2, 2))
         # Create a subset of the (n, 2, 2) array above using the array of indexes
-        for i in len(indexes):
-            for j in len(point_pairs):
+        for i in range(0, len(indexes)):
+            for j in range (0, len(point_pairs)):
                 if i == j:
                     non_collinear_points = np.concatenate((non_collinear_points, point_pairs[j]))
                     # non_collinear_points only stores the 4 non-collinear point pairs

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -241,9 +241,9 @@ class Geolocation:
                                                                              points[(k + 2) % NUM_POINTS_NEEDED])
                 # Store indexes of current iteration
                 indexes[0] = (i)
-                indexes[1] = ((i + 1) % NUM_POINTS_NEEDED)
-                indexes[2] = ((i + 2) % NUM_POINTS_NEEDED)
-                indexes[3] = ((i + 3) % NUM_POINTS_NEEDED)
+                indexes[1] = ((i + 1) % len(coordinatesArray))
+                indexes[2] = ((i + 2) % len(coordinatesArray))
+                indexes[3] = ((i + 3) % len(coordinatesArray))
 
                 # If points are collinear, stop looping
                 if (areNotFourCollinear == False):
@@ -609,7 +609,7 @@ class Geolocation:
         if len(indexes) < 4:
             return False, None
 
-        non_collinear_points = np.empty(shape=(4, 2, 2))
+        non_collinear_points = np.array(indexes)
 
         # Create a subset of the (n, 2, 2) array above using the array of indexes
         non_collinear_points = [point_pairs[i] for i in indexes]

--- a/tests/test_geolocation.py
+++ b/tests/test_geolocation.py
@@ -168,7 +168,8 @@ class TestGetNonCollinearPoints(unittest.TestCase):
 
     def test_four_points_non_collinear(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
-        expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
+        # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
+        expected = np.array[0, 1, 2, 3]
 
         # Run
         actual = self.locator.get_non_collinear_points(coordinatesArray)
@@ -178,7 +179,8 @@ class TestGetNonCollinearPoints(unittest.TestCase):
 
     def test_more_than_four_points_one_correct_case(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0], [4, 4]])
-        expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
+        # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
+        expected = np.array[0, 1, 2, 3]
 
         # Run
         actual = self.locator.get_non_collinear_points(coordinatesArray)

--- a/tests/test_geolocation.py
+++ b/tests/test_geolocation.py
@@ -169,7 +169,7 @@ class TestGetNonCollinearPoints(unittest.TestCase):
     def test_four_points_non_collinear(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
         # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
-        expected = np.array[0, 1, 2, 3]
+        expected = np.array([0, 1, 2, 3])
 
         # Run
         actual = self.locator.get_non_collinear_points(coordinatesArray)
@@ -180,7 +180,7 @@ class TestGetNonCollinearPoints(unittest.TestCase):
     def test_more_than_four_points_one_correct_case(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0], [4, 4]])
         # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
-        expected = np.array[0, 1, 2, 3]
+        expected = np.array([0, 1, 2, 3])
 
         # Run
         actual = self.locator.get_non_collinear_points(coordinatesArray)

--- a/tests/test_geolocation.py
+++ b/tests/test_geolocation.py
@@ -199,7 +199,7 @@ class TestGetNonCollinearPoints(unittest.TestCase):
         np.testing.assert_almost_equal(actual, expected)
 
     def test_more_than_four_points_last_correct_case(self):
-        coordinatesArray = np.array([[0, 0], [1, 1], [100, 0], [-1, -1], [4, 4], [2, -2], [-4, 10]])
+        coordinatesArray = np.array([[0, 0], [1, 1], [100, 0], [-1, -1], [4, 4], [-2, -2], [-4, 10]])
         expected = np.array([0, 1, 2, 6])
 
         # Run 

--- a/tests/test_geolocation.py
+++ b/tests/test_geolocation.py
@@ -168,7 +168,6 @@ class TestGetNonCollinearPoints(unittest.TestCase):
 
     def test_four_points_non_collinear(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
-        # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
         expected = np.array([0, 1, 2, 3])
 
         # Run
@@ -179,7 +178,6 @@ class TestGetNonCollinearPoints(unittest.TestCase):
 
     def test_more_than_four_points_one_correct_case(self):
         coordinatesArray = np.array([[0, 0], [10, 12], [-1, -1], [100, 0], [4, 4]])
-        # expected = np.array([[0, 0], [10, 12], [-1, -1], [100, 0]])
         expected = np.array([0, 1, 2, 3])
 
         # Run
@@ -196,6 +194,16 @@ class TestGetNonCollinearPoints(unittest.TestCase):
         # Run
         points = self.locator.get_non_collinear_points(coordinatesArray)
         actual = np.size(points)
+
+        # Test
+        np.testing.assert_almost_equal(actual, expected)
+
+    def test_more_than_four_points_last_correct_case(self):
+        coordinatesArray = np.array([[0, 0], [1, 1], [100, 0], [-1, -1], [4, 4], [2, -2], [-4, 10]])
+        expected = np.array([0, 1, 2, 6])
+
+        # Run 
+        actual = self.locator.get_non_collinear_points(coordinatesArray)
 
         # Test
         np.testing.assert_almost_equal(actual, expected)


### PR DESCRIPTION
Modified files geolocation.py and test_geolocation.py, refactored the get_non_collinear_points() function in geolocation.py according to Ryan's Specification 2 in #geolocation. It now returns an array of indexes that we want to find to create a subarray of an (n, 2, 2) array in run_locator(). test_geolocation.py was changed accordingly to assert the output array of indexes, for ex [0, 1, 2, 3]. 