### PR TITLE
Wrote code for tracking the world model of landing pads

### DIFF
--- a/modules/controller/landing_pack_tracking.py
+++ b/modules/controller/landing_pack_tracking.py
@@ -1,91 +1,84 @@
 """
-keeps track of detected and visited landing pads
+Keeps track of detected and visited landing pads
 """
 
 import numpy as np
 
-from .. import object_in_world  #Edit name when finalized
+from .. import object_in_world
 
 
 class LandingPadTracking:
     """
-    keeps track of the real world location of landing pads that
-    are to be visited or have already been vsisited
+    Keeps track of the real world location of landing pads that are to be visited or have already been vsisited
     """
-    def __init__(self, distance_threshold: float):
+    def __init__(self, distance_squared_threshold: float):
         self.__unconfirmed_positives = []
         self.__false_positives = []
         self.__confirmed_positives = []
 
         # Landing pads within the square root of this distance are considered the same landing pad
-        self.__distance_threshold = distance_threshold
+        self.__distance_squared_threshold = distance_squared_threshold
 
     @staticmethod
-    def __similar(detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld, distance_squared_threshold: float) -> bool:
+    def __is_similar(detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld, distance_squared_threshold: float) -> bool:
         """
-        returns whether detection1 and detection2 are close enough
-        to be considered the same landing pad
+        Returns whether detection1 and detection2 are close enough to be considered the same landing pad
         """
-
         distance_squared = (detection2.position_x - detection1.position_x) ** 2 + (detection2.position_y - detection1.position_y) ** 2
         return distance_squared < distance_squared_threshold
 
     def mark_false_positive(self, detection: object_in_world.ObjectInWorld):
         """
-        marks a detection as false positive and removes similar landing
-        pads from the list of unconfirmed positives
+        Marks a detection as false positive and removes similar landing pads from the list of unconfirmed positives
         """
-
         self.__false_positives.append(detection)
         for landing_pad in self.__unconfirmed_positives:
-            if self.__similar(landing_pad, detection, self.__distance_threshold):
+            if self.__is_similar(landing_pad, detection, self.__distance_squared_threshold):
                 self.__unconfirmed_positives.remove(landing_pad)
 
     def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) -> object_in_world.ObjectInWorld:
         """
-        marks a detection as a confimred positive for future use
+        Marks a detection as a confimred positive for future use
         """
-
         self.__confirmed_positives.append(detection)
         
-    def run(self, detections: np.ndarray):
+    def run(self, detections: "list[object_in_world.ObjectInWorld]"):
         """
-        updates the list of unconfirmed positives and returns the
-        detection with the lowest variance
+        Updates the list of unconfirmed positives and returns the detection with the lowest variance
         """
         for detection in detections:
             match_found = False
 
-            # if detection matches a false positive, don't add it
+            # If detection matches a false positive, don't add it
             for false_positive in self.__false_positives:
-                if self.__similar(detection, false_positive, self.__distance_threshold):
+                if self.__is_similar(detection, false_positive, self.__distance_squared_threshold):
                     match_found = True
                     break
             if match_found:
                 continue
 
-            # if detection matches an unconfirmed positive, replace old detection
+            # If detection matches an unconfirmed positive, replace old detection
             for i, landing_pad in enumerate(self.__unconfirmed_positives):
-                if self.__similar(detection, landing_pad, self.__distance_threshold):
+                if self.__is_similar(detection, landing_pad, self.__distance_squared_threshold):
                     match_found = True
                     self.__unconfirmed_positives[i] = detection
                     break
             if match_found:
                 continue
 
-            # if new landing pad, add to list of unconfirmed positives
+            # If new landing pad, add to list of unconfirmed positives
             self.__unconfirmed_positives.append(detection)
 
-        # there are confirmed positives, return the first one
+        # If there are confirmed positives, return the first one
         if len(self.__confirmed_positives) > 0:
             return True, self.__confirmed_positives[0]
 
-        # if the list is empty, all landing pads have been visited, none are viable
+        # If the list is empty, all landing pads have been visited, none are viable
         if len(self.__unconfirmed_positives) == 0:
             return False, None
-        
-        # sort list by variance in ascending order
+                
+        # Sort list by variance in ascending order
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
 
-        # return detection with lowest variance
+        # Return detection with lowest variance
         return True, self.__unconfirmed_positives[0]

--- a/modules/controller/landing_pack_tracking.py
+++ b/modules/controller/landing_pack_tracking.py
@@ -83,5 +83,9 @@ class LandingPadTracking:
         # sort list by variance in ascending order
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
 
+        # there are confirmed positives, return the first one
+        if len(self.confirmed_positives) > 0:
+            return True, self.confirmed_positives[0]
+
         # return detection with lowest variance
         return True, self.__unconfirmed_positives[0]

--- a/modules/controller/landing_pack_tracking.py
+++ b/modules/controller/landing_pack_tracking.py
@@ -7,7 +7,7 @@ import numpy as np
 from .. import object_in_world  #Edit name when finalized
 
 
-class WorldModelTracking:
+class LandingPadTracking:
     """
     keeps track of the real world location of landing pads that
     are to be visited or have already been vsisited

--- a/modules/controller/landing_pack_tracking.py
+++ b/modules/controller/landing_pack_tracking.py
@@ -15,7 +15,7 @@ class LandingPadTracking:
     def __init__(self, distance_threshold: float):
         self.__unconfirmed_positives = []
         self.__false_positives = []
-        self.confirmed_positives = []
+        self.__confirmed_positives = []
 
         # Landing pads within the square root of this distance are considered the same landing pad
         self.__distance_threshold = distance_threshold
@@ -46,7 +46,7 @@ class LandingPadTracking:
         marks a detection as a confimred positive for future use
         """
 
-        self.confirmed_positives.append(detection)
+        self.__confirmed_positives.append(detection)
         
     def run(self, detections: np.ndarray):
         """
@@ -84,8 +84,8 @@ class LandingPadTracking:
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
 
         # there are confirmed positives, return the first one
-        if len(self.confirmed_positives) > 0:
-            return True, self.confirmed_positives[0]
+        if len(self.__confirmed_positives) > 0:
+            return True, self.__confirmed_positives[0]
 
         # return detection with lowest variance
         return True, self.__unconfirmed_positives[0]

--- a/modules/controller/landing_pack_tracking.py
+++ b/modules/controller/landing_pack_tracking.py
@@ -76,16 +76,16 @@ class LandingPadTracking:
             # if new landing pad, add to list of unconfirmed positives
             self.__unconfirmed_positives.append(detection)
 
+        # there are confirmed positives, return the first one
+        if len(self.__confirmed_positives) > 0:
+            return True, self.__confirmed_positives[0]
+
         # if the list is empty, all landing pads have been visited, none are viable
         if len(self.__unconfirmed_positives) == 0:
             return False, None
         
         # sort list by variance in ascending order
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
-
-        # there are confirmed positives, return the first one
-        if len(self.__confirmed_positives) > 0:
-            return True, self.__confirmed_positives[0]
 
         # return detection with lowest variance
         return True, self.__unconfirmed_positives[0]

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -32,8 +32,10 @@ class LandingPadTracking:
         Marks a detection as false positive and removes similar landing pads from the list of unconfirmed positives
         """
         self.__false_positives.append(detection)
-        self.__unconfirmed_positives = [landing_pad for landing_pad in self.__unconfirmed_positives
-                                        if not self.__is_similar(landing_pad, detection, self.__distance_squared_threshold)]
+        self.__unconfirmed_positives = [
+            landing_pad for landing_pad in self.__unconfirmed_positives
+            if not self.__is_similar(landing_pad, detection, self.__distance_squared_threshold)
+        ]
 
     def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld):
         """

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -32,9 +32,7 @@ class LandingPadTracking:
         Marks a detection as false positive and removes similar landing pads from the list of unconfirmed positives
         """
         self.__false_positives.append(detection)
-        for landing_pad in self.__unconfirmed_positives:
-            if self.__is_similar(landing_pad, detection, self.__distance_squared_threshold):
-                self.__unconfirmed_positives.remove(landing_pad)
+        self.__unconfirmed_positives = [landing_pad for i,landing_pad in enumerate(self.__unconfirmed_positives) if not self.__is_similar(landing_pad, detection, self.__distance_squared_threshold)]
 
     def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld):
         """

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -44,7 +44,8 @@ class LandingPadTracking:
         
     def run(self, detections: "list[object_in_world.ObjectInWorld]"):
         """
-        Updates the list of unconfirmed positives and returns the detection with the lowest variance
+        Updates the list of unconfirmed positives and returns the a first confirmed positive if one exists,
+        else the unconfirmed positive with the lowest variance
         """
         for detection in detections:
             match_found = False

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -33,7 +33,6 @@ class LandingPadTracking:
         """
         self.__false_positives.append(detection)
         for landing_pad in self.__unconfirmed_positives:
-            print(landing_pad.spherical_variance, detection.spherical_variance)
             if self.__is_similar(landing_pad, detection, self.__distance_squared_threshold):
                 self.__unconfirmed_positives.remove(landing_pad)
 

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -9,8 +9,8 @@ from .. import object_in_world
 
 class LandingPadTracking:
     """
-    Keeps track of the real world location of landing pads that are to be visited or have already
-    been vsisited
+    Tracks the real world location of detected landing pads, labelling them as either confirmed
+    positive, unconfirmed positive, or false positive
     """
     def __init__(self, distance_squared_threshold: float):
         self.__unconfirmed_positives = []

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -9,7 +9,8 @@ from .. import object_in_world
 
 class LandingPadTracking:
     """
-    Keeps track of the real world location of landing pads that are to be visited or have already been vsisited
+    Keeps track of the real world location of landing pads that are to be visited or have already
+    been vsisited
     """
     def __init__(self, distance_squared_threshold: float):
         self.__unconfirmed_positives = []
@@ -20,16 +21,21 @@ class LandingPadTracking:
         self.__distance_squared_threshold = distance_squared_threshold
 
     @staticmethod
-    def __is_similar(detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld, distance_squared_threshold: float) -> bool:
+    def __is_similar(detection1: object_in_world.ObjectInWorld,
+                     detection2: object_in_world.ObjectInWorld,
+                     distance_squared_threshold: float) -> bool:
         """
-        Returns whether detection1 and detection2 are close enough to be considered the same landing pad
+        Returns whether detection1 and detection2 are close enough to be considered the same
+        landing pad
         """
-        distance_squared = (detection2.position_x - detection1.position_x) ** 2 + (detection2.position_y - detection1.position_y) ** 2
+        distance_squared = (detection2.position_x - detection1.position_x) ** 2 \
+                           + (detection2.position_y - detection1.position_y) ** 2
         return distance_squared < distance_squared_threshold
 
     def mark_false_positive(self, detection: object_in_world.ObjectInWorld):
         """
-        Marks a detection as false positive and removes similar landing pads from the list of unconfirmed positives
+        Marks a detection as false positive and removes similar landing pads from the list of
+        unconfirmed positives
         """
         self.__false_positives.append(detection)
         self.__unconfirmed_positives = [
@@ -45,8 +51,8 @@ class LandingPadTracking:
         
     def run(self, detections: "list[object_in_world.ObjectInWorld]"):
         """
-        Updates the list of unconfirmed positives and returns the a first confirmed positive if one exists,
-        else the unconfirmed positive with the lowest variance
+        Updates the list of unconfirmed positives and returns the a first confirmed positive if
+        one exists, else the unconfirmed positive with the lowest variance
         """
         for detection in detections:
             match_found = False

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -32,7 +32,8 @@ class LandingPadTracking:
         Marks a detection as false positive and removes similar landing pads from the list of unconfirmed positives
         """
         self.__false_positives.append(detection)
-        self.__unconfirmed_positives = [landing_pad for i,landing_pad in enumerate(self.__unconfirmed_positives) if not self.__is_similar(landing_pad, detection, self.__distance_squared_threshold)]
+        self.__unconfirmed_positives = [landing_pad for landing_pad in self.__unconfirmed_positives
+                                        if not self.__is_similar(landing_pad, detection, self.__distance_squared_threshold)]
 
     def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld):
         """

--- a/modules/controller/landing_pad_tracking.py
+++ b/modules/controller/landing_pad_tracking.py
@@ -33,10 +33,11 @@ class LandingPadTracking:
         """
         self.__false_positives.append(detection)
         for landing_pad in self.__unconfirmed_positives:
+            print(landing_pad.spherical_variance, detection.spherical_variance)
             if self.__is_similar(landing_pad, detection, self.__distance_squared_threshold):
                 self.__unconfirmed_positives.remove(landing_pad)
 
-    def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) -> object_in_world.ObjectInWorld:
+    def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld):
         """
         Marks a detection as a confimred positive for future use
         """

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -1,0 +1,33 @@
+
+
+class WorldModelTracking:
+
+    def __init__(self):
+        self.__unconfirmed_positives = []
+        self.__false_positives = []
+        self.__unconfirmed_positives = None         #object in world
+    
+    def similar(self, detection1, detection2):
+        pass
+
+    def run(self, detections):
+        for detection in detections:
+            match_found = False
+            for false_positive in self.__false_positives:
+                if self.similar(detection, false_positive):
+                    match_found = True
+                    break
+            if match_found:
+                continue
+            for i, landing_pad in enumerate(self.__unconfirmed_positives):
+                if self.similar(detection, landing_pad):
+                    match_found = True
+                    self.__unconfirmed_positives[i] = detection
+                    break
+            if match_found:
+                continue
+            self.__unconfirmed_positives.append(detection)
+        
+        self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
+
+        return True, self.__unconfirmed_positives[-1]

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -12,22 +12,23 @@ class WorldModelTracking:
     keeps track of the real world location of landing pads that
     are to be visited or have already been vsisited
     """
-
-    def __init__(self):
+    
+    def __init__(self, distance_threshold: int):
         self.__unconfirmed_positives = []
         self.__false_positives = []
         self.confirmed_positives = []
 
-    @staticmethod
-    def __similar(detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
+        #Landing pads within the square root of this distance are considered the same landing pad
+        self.DISTANCE_THRESHOLD = distance_threshold
+
+    def __similar(self, detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
         """
         returns whether detection1 and detection2 are close enough
         to be considered the same landing pad
         """
 
-        DISTANCE_THRESHOLD = 2
-        distance = (detection2.position_x - detection1.position_x) ** 2 + (detection2.position_y - detection1.position_y) ** 2
-        return distance < DISTANCE_THRESHOLD
+        distance_squared = (detection2.position_x - detection1.position_x) ** 2 + (detection2.position_y - detection1.position_y) ** 2
+        return distance_squared < self.DISTANCE_THRESHOLD
 
     def mark_false_positive(self, detection: object_in_world.ObjectInWorld):
         """

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -16,7 +16,7 @@ class WorldModelTracking:
     def __init__(self):
         self.__unconfirmed_positives = []
         self.__false_positives = []
-        self.confirmed_positive = None
+        self.confirmed_positives = []
 
     def __similar(self, detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
         """
@@ -34,20 +34,19 @@ class WorldModelTracking:
         pads from the list of unconfirmed positives
         """
 
-        self.__false_positives += [detection]
+        self.__false_positives.append(detection)
         for landing_pad in self.__unconfirmed_positives:
             if self.__similar(landing_pad, detection):
                 self.__unconfirmed_positives.remove(landing_pad)
-                break
-        return detection
+        return True
 
     def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) -> object_in_world.ObjectInWorld:
         """
         marks a detection as a confimred positive for future use
         """
 
-        self.confirmed_positive = detection
-        return self.confirmed_positive
+        self.confirmed_positives.append(detection)
+        return True
 
     def run(self, detections: np.ndarray):
         """

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -4,7 +4,7 @@ keeps track of detected and visited landing pads
 
 import numpy as np
 
-from .. import object_in_world
+from .. import object_in_world  #Edit name when finalized
 
 
 class WorldModelTracking:

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -1,3 +1,7 @@
+"""
+keeps track of detected and visited landing pads
+"""
+
 import numpy as np
 
 from .. import object_in_world
@@ -14,18 +18,14 @@ class WorldModelTracking:
         self.__false_positives = []
         self.confirmed_positive = None
 
-    def __similar(self,
-                  detection1: object_in_world.ObjectInWorld,
-                  detection2: object_in_world.ObjectInWorld) \
-                -> bool:
+    def __similar(self, detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
         """
         returns whether detection1 and detection2 are close enough
         to be considered the same landing pad
         """
 
         DISTANCE_THRESHOLD = 2
-        distance = (detection2.position_x - detection1.position_x) ** 2 \
-                 + (detection2.position_y - detection1.position_y) ** 2
+        distance = (detection2.position_x - detection1.position_x) ** 2 + (detection2.position_y - detection1.position_y) ** 2
         return distance < DISTANCE_THRESHOLD
 
     def mark_false_positive(self, detection: object_in_world.ObjectInWorld):
@@ -41,8 +41,7 @@ class WorldModelTracking:
                 break
         return detection
 
-    def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) \
-                                -> object_in_world.ObjectInWorld:
+    def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) -> object_in_world.ObjectInWorld:
         """
         marks a detection as a confimred positive for future use
         """
@@ -55,9 +54,9 @@ class WorldModelTracking:
         updates the list of unconfirmed positives and returns the
         detection with the lowest variance
         """
-
         for detection in detections:
             match_found = False
+
             # if detection matches a false positive, don't add it
             for false_positive in self.__false_positives:
                 if self.__similar(detection, false_positive):
@@ -65,6 +64,7 @@ class WorldModelTracking:
                     break
             if match_found:
                 continue
+
             # if detection matches an unconfirmed positive, replace old detection
             for i, landing_pad in enumerate(self.__unconfirmed_positives):
                 if self.__similar(detection, landing_pad):
@@ -73,6 +73,7 @@ class WorldModelTracking:
                     break
             if match_found:
                 continue
+
             # if new landing pad, add to list of unconfirmed positives
             self.__unconfirmed_positives.append(detection)
 
@@ -80,7 +81,8 @@ class WorldModelTracking:
         if len(self.__unconfirmed_positives) == 0:
             return False, None
         
-        # sort list by variance
+        # sort list by variance in ascending order
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
+
         # return detection with lowest variance
         return True, self.__unconfirmed_positives[0]

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -18,7 +18,8 @@ class WorldModelTracking:
         self.__false_positives = []
         self.confirmed_positives = []
 
-    def __similar(self, detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
+    @staticmethod
+    def __similar(detection1: object_in_world.ObjectInWorld, detection2: object_in_world.ObjectInWorld) -> bool:
         """
         returns whether detection1 and detection2 are close enough
         to be considered the same landing pad

--- a/modules/controller/world_model_tracking.py
+++ b/modules/controller/world_model_tracking.py
@@ -1,33 +1,77 @@
+import numpy as np
+
+from .. import object_in_world
 
 
 class WorldModelTracking:
+    """
+    keeps track of the real world location of landing pads that
+    are to be visited or have already been vsisited
+    """
 
     def __init__(self):
         self.__unconfirmed_positives = []
         self.__false_positives = []
-        self.__unconfirmed_positives = None         #object in world
-    
-    def similar(self, detection1, detection2):
-        pass
+        self.confirmed_positive = None
 
-    def run(self, detections):
+    def __similar(self,
+                  detection1: object_in_world.ObjectInWorld,
+                  detection2: object_in_world.ObjectInWorld) \
+            -> bool:
+        """
+        returns whether detection1 and detection2 are close enough
+        to be considered the same landing
+        """
+
+        DISTANCE_THRESHOLD = 0.2
+        distance = (detection2.position_x - detection1.position_x) ** 2 \
+            + (detection2.position_y - detection1.position_y) ** 2
+        return distance < DISTANCE_THRESHOLD
+
+    def mark_false_positive(self, detection: object_in_world.ObjectInWorld) \
+                            -> object_in_world.ObjectInWorld:
+        """
+        marks a detection as false positive
+        """
+
+        self.__false_positives += [detection]
+        for landing_pad in self.__unconfirmed_positives:
+            if self.__similar(landing_pad, detection):
+                self.__unconfirmed_positives.remove(detection)
+        return detection
+
+    def mark_confirmed_positive(self, detection: object_in_world.ObjectInWorld) \
+                                -> object_in_world.ObjectInWorld:
+        """
+        marks a detection as a confimred positive for future use
+        """
+
+        self.confirmed_positive = detection
+        return self.confirmed_positive
+
+    def run(self, detections: np.ndarray):
+        """
+        updates the list of unconfirmed positives and returns the
+        detection with the lowest variance
+        """
+        
         for detection in detections:
             match_found = False
             for false_positive in self.__false_positives:
-                if self.similar(detection, false_positive):
+                if self.__similar(detection, false_positive):
                     match_found = True
                     break
             if match_found:
                 continue
             for i, landing_pad in enumerate(self.__unconfirmed_positives):
-                if self.similar(detection, landing_pad):
+                if self.__similar(detection, landing_pad):
                     match_found = True
                     self.__unconfirmed_positives[i] = detection
                     break
             if match_found:
                 continue
             self.__unconfirmed_positives.append(detection)
-        
+
         self.__unconfirmed_positives.sort(key=lambda x: x.spherical_variance)
 
-        return True, self.__unconfirmed_positives[-1]
+        return self.__unconfirmed_positives[0]

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -64,79 +64,98 @@ def detections3():
 
 class TestSimilar:
     """
-    Test if similar function correctly determines if 2 landing pads are close enough to be considered similar
+    Test if similar function correctly determines if 2 landing pads are close enough to be
+    considered similar
     """
     # Required for testing
     # pylint: disable=protected-access
     def test_is_similar_positive_equal_to_threshold(self):
         """
-        Test case where the second landing pad has positive coordinates and the distance between them is equal to the distance threshold
+        Test case where the second landing pad has positive coordinates and the distance between
+        them is equal to the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(1, 1, 0)[1]
         expected = False
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+        )
 
         assert actual == expected
 
     def test_is_similar_negative_equal_to_threshold(self):
         """
-        Test case where the second landing pad has negative coordinates and the distance between them is equal to the distance threshold
+        Test case where the second landing pad has negative coordinates and the distance between
+        them is equal to the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(-1, -1, 0)[1]
         expected = False
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+        )
 
         assert actual == expected
 
     def test_is_similar_positive_less_than_threshold(self):
         """
-        Test case where the second landing pad has positive coordinates and the distance between them is less than the distance threshold
+        Test case where the second landing pad has positive coordinates and the distance between
+        them is less than the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(0.5, 0.5, 0)[1]
         expected = True
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+        )
 
         assert actual == expected
 
     def test_is_similar_negative_less_than_threshold(self):
         """
-        Test case where the second landing pad has negative coordinates and the distance between them is less than the distance threshold
+        Test case where the second landing pad has negative coordinates and the distance between
+        them is less than the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(-0.5, -0.5, 0)[1]
         expected = True
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            )
 
         assert actual == expected
 
     def test_is_similar_positive_more_than_threshold(self):
         """
-        Test case where the second landing pad has positive coordinates and the distance between them is more than the distance threshold
+        Test case where the second landing pad has positive coordinates and the distance between
+        them is more than the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(2, 2, 0)[1]
         expected = False
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            )
 
         assert actual == expected
 
     def test_is_similar_negative_more_than_threshold(self):
         """
-        Test case where the second landing pad has negative coordinates and the distance between them is more than the distance threshold
+        Test case where the second landing pad has negative coordinates and the distance between
+        them is more than the distance threshold
         """
         obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
         obj2 = object_in_world.ObjectInWorld.create(-2, -2, 0)[1]
         expected = False
 
-        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
+            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+        )
 
         assert actual == expected
 
@@ -148,23 +167,34 @@ class TestMarkFalsePositive:
     """
     # Required for testing
     # pylint: disable=protected-access
-    def test_mark_false_positive_no_similar(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_false_positive_no_similar(self,
+                                            tracker: landing_pad_tracking.LandingPadTracking,
+                                            detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives
         """
         false_positive = object_in_world.ObjectInWorld.create(20, 20, 20)[1]
         tracker._LandingPadTracking__unconfirmed_positives = detections1
         expected = [false_positive]
-        expected_unconfirmed_positives = [detections1[0], detections1[1], detections1[2], detections1[3], detections1[4]]
+        expected_unconfirmed_positives = [
+            detections1[0],
+            detections1[1],
+            detections1[2],
+            detections1[3],
+            detections1[4]
+        ]
         
         tracker.mark_false_positive(false_positive)
 
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_mark_false_positive_with_similar(self, tracker: landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_false_positive_with_similar(self,
+                                              tracker: landing_pad_tracking.LandingPadTracking,
+                                              detections2: "list[object_in_world.ObjectInWorld]"):
         """
-        Test if marking false positive adds detection to list of false positives and removes similar landing pads
+        Test if marking false positive adds detection to list of false positives and removes
+        similar landing pads
         """
         false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
         tracker._LandingPadTracking__unconfirmed_positives = detections2
@@ -176,7 +206,9 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
-    def test_mark_multiple_false_positive(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_multiple_false_positive(self,
+                                          tracker: landing_pad_tracking.LandingPadTracking,
+                                          detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives
         """
@@ -191,7 +223,6 @@ class TestMarkFalsePositive:
 
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
-
 
     # pylint: enable=protected-access
 
@@ -213,7 +244,8 @@ class TestMarkConfirmedPositive:
 
         assert tracker._LandingPadTracking__confirmed_positives == expected
     
-    def test_mark_multiple_confirmed_positives(self, tracker: landing_pad_tracking.LandingPadTracking):
+    def test_mark_multiple_confirmed_positives(self,
+                                               tracker: landing_pad_tracking.LandingPadTracking):
         """
         Test if marking confirmed positive adds detection to list of confirmed positives
         """
@@ -243,12 +275,20 @@ class TestLandingPadTracking:
         assert not result
         assert actual is None
 
-    def test_run_single_input(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_run_one_input(self,
+                              tracker: landing_pad_tracking.LandingPadTracking,
+                              detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with only 1 input
         """
         expected_output = detections1[2]
-        expected_unconfirmed_positives = [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+        expected_unconfirmed_positives = [
+            detections1[2],
+            detections1[1],
+            detections1[4],
+            detections1[0],
+            detections1[3]
+        ]
         
         result, actual = tracker.run(detections1)
         
@@ -256,12 +296,19 @@ class TestLandingPadTracking:
         assert actual == expected_output
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_run_single_input_similar_detections(self, tracker: landing_pad_tracking.LandingPadTracking, detections3: "list[object_in_world.ObjectInWorld]"):
+    def test_run_one_input_similar_detections(self,
+                                              tracker: landing_pad_tracking.LandingPadTracking,
+                                              detections3: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with only 1 input where 2 landing pads are similar
         """        
         expected_output = detections3[2]
-        expected_unconfirmed_positives = [detections3[2], detections3[1], detections3[4], detections3[3]]
+        expected_unconfirmed_positives = [
+            detections3[2],
+            detections3[1],
+            detections3[4],
+            detections3[3]
+        ]
         
         result, actual = tracker.run(detections3)
 
@@ -269,12 +316,24 @@ class TestLandingPadTracking:
         assert actual == expected_output
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_run_multiple_inputs(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]", detections2: "list[object_in_world.ObjectInWorld]"):
+    def test_run_multiple_inputs(self,
+                                 tracker: landing_pad_tracking.LandingPadTracking,
+                                 detections1: "list[object_in_world.ObjectInWorld]",
+                                 detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with 2 inputs where some landing pads are similar
         """
         expected_output = detections2[0]
-        expected_unconfirmed_positives = [detections2[0], detections1[2], detections2[1], detections2[3], detections1[4], detections2[2], detections2[4], detections1[3]]
+        expected_unconfirmed_positives = [
+            detections2[0],
+            detections1[2],
+            detections2[1],
+            detections2[3],
+            detections1[4],
+            detections2[2],
+            detections2[4],
+            detections1[3]
+        ]
 
         tracker.run(detections1)
         result, actual = tracker.run(detections2)
@@ -283,7 +342,9 @@ class TestLandingPadTracking:
         assert actual == expected_output
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_run_with_confirmed_positive(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_run_with_confirmed_positive(self,
+                                         tracker: landing_pad_tracking.LandingPadTracking,
+                                         detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test run when there is a confirmed positive
         """
@@ -296,11 +357,15 @@ class TestLandingPadTracking:
         assert result
         assert actual == expected
     
-    def test_run_with_false_positive(self, tracker: landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
+    def test_run_with_false_positive(self,
+                                     tracker: landing_pad_tracking.LandingPadTracking,
+                                     detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test to see if run function doesn't add landing pads that are similar to false positives
         """
-        tracker._LandingPadTracking__false_positives.append(object_in_world.ObjectInWorld.create(1, 1, 1)[1])
+        tracker._LandingPadTracking__false_positives.append(
+            object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        )
         expected_unconfirmed_positives = [detections2[3], detections2[2], detections2[4]]
 
         tracker.run(detections2)

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -61,35 +61,89 @@ def detections3():
     detections3 = [obj1, obj2, obj3, obj4, obj5]
     yield detections3
 
+class TestSimilar:
+    """
+    Test if similar function correctly determines if 2 landing pads are close enough to be considered similar
+    """
+
+    def test_is_similar_positive_equal_to_threshold(self):
+        """
+        Test case where the second landing pad has positive coordinates and the distance between them is equal to the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(1, 1, 0)[1]
+        expected = False
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
+    def test_is_similar_negative_equal_to_threshold(self):
+        """
+        Test case where the second landing pad has negative coordinates and the distance between them is equal to the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-1, -1, 0)[1]
+        expected = False
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
+    def test_is_similar_positive_less_than_threshold(self):
+        """
+        Test case where the second landing pad has positive coordinates and the distance between them is less than the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(0.5, 0.5, 0)[1]
+        expected = True
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
+    def test_is_similar_negative_less_than_threshold(self):
+        """
+        Test case where the second landing pad has negative coordinates and the distance between them is less than the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-0.5, -0.5, 0)[1]
+        expected = True
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
+    def test_is_similar_positive_more_than_threshold(self):
+        """
+        Test case where the second landing pad has positive coordinates and the distance between them is more than the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(2, 2, 0)[1]
+        expected = False
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
+    def test_is_similar_negative_more_than_threshold(self):
+        """
+        Test case where the second landing pad has negative coordinates and the distance between them is more than the distance threshold
+        """
+        obj1 = object_in_world.ObjectInWorld.create(0, 0, 0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-2, -2, 0)[1]
+        expected = False
+
+        actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+        assert actual == expected
+
 class TestLandingPadTracking:
     """
     Test landing pad tracking run function
     """
     # Required for testing
     # pylint: disable=protected-access
-    def test_is_similar(self):
-        """
-        Test if similar function correctly determines if 2 landing pads are close enough to be considered similar
-        """
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(-1,-1,0)[1]
-        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(1,1,0)[1]
-        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(0.5,0.5,0)[1]
-        assert landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(-0.5,-0.5,0)[1]
-        assert landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(2,2,0)[1]
-        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
-        obj2 = object_in_world.ObjectInWorld.create(-2,-2,0)[1]
-        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
-
     def test_run_with_empty_detections_list(self, tracker: landing_pad_tracking.LandingPadTracking):
         """
         Test run method with empty detections list

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -8,7 +8,7 @@ from modules import object_in_world
 from modules.controller import landing_pad_tracking
 
 
-DISTANCE_SQUARED_THRESHOLD = 2          # Actual distance threshold is sqrt(2)
+DISTANCE_SQUARED_THRESHOLD = 2  # Actual distance threshold is sqrt(2)
 
 
 @pytest.fixture()
@@ -176,6 +176,23 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
+    def test_mark_multiple_false_positive(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test if marking false positive adds detection to list of false positives
+        """
+        false_positive1 = object_in_world.ObjectInWorld.create(20, 20, 1)[1]
+        false_positive2 = object_in_world.ObjectInWorld.create(40, 40, 1)[1]
+        tracker._LandingPadTracking__unconfirmed_positives = detections1
+        expected = [false_positive1, false_positive2]
+        expected_unconfirmed_positives = [detections1[0], detections1[1], detections1[2], detections1[3], detections1[4]]
+        
+        tracker.mark_false_positive(false_positive1)
+        tracker.mark_false_positive(false_positive2)
+
+        assert tracker._LandingPadTracking__false_positives == expected
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
+
+
     # pylint: enable=protected-access
 
 
@@ -193,6 +210,19 @@ class TestMarkConfirmedPositive:
         expected = [confirmed_positive]
         
         tracker.mark_confirmed_positive(confirmed_positive)
+
+        assert tracker._LandingPadTracking__confirmed_positives == expected
+    
+    def test_mark_multiple_confirmed_positives(self, tracker: landing_pad_tracking.LandingPadTracking):
+        """
+        Test if marking confirmed positive adds detection to list of confirmed positives
+        """
+        confirmed_positive1 = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        confirmed_positive2 = object_in_world.ObjectInWorld.create(2, 2, 1)[1]
+        expected = [confirmed_positive1, confirmed_positive2]
+        
+        tracker.mark_confirmed_positive(confirmed_positive1)
+        tracker.mark_confirmed_positive(confirmed_positive2)
 
         assert tracker._LandingPadTracking__confirmed_positives == expected
 

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -1,0 +1,112 @@
+"""
+Test landing pad tracking
+"""
+
+import pytest
+
+from modules import object_in_world
+from modules.controller import landing_pad_tracking
+
+DISTANCE_SQUARED_THRESHOLD = 2
+
+@pytest.fixture()
+def tracker():
+    """
+    instantiates model tracking
+    """
+    tracker = landing_pad_tracking.LandingPadTracking(DISTANCE_SQUARED_THRESHOLD)
+    yield tracker
+
+@pytest.fixture
+def detections1():
+    """
+    # Sample instances of 'object_in_world.ObjectInWorld' for testing
+    """
+    obj1 = object_in_world.ObjectInWorld.create(0,0,8)[1]
+    obj2 = object_in_world.ObjectInWorld.create(2,2,4)[1]
+    obj3 = object_in_world.ObjectInWorld.create(-2,-2,2)[1]
+    obj4 = object_in_world.ObjectInWorld.create(3,3,10)[1]
+    obj5 = object_in_world.ObjectInWorld.create(-3,-3,6)[1]
+    detections1 = [obj1, obj2, obj3, obj4, obj5]
+    yield detections1
+
+@pytest.fixture
+def detections2():
+    """
+    Sample instances of 'object_in_world.ObjectInWorld' for testing
+    """
+    obj1 = object_in_world.ObjectInWorld.create(0.5,0.5,1)[1]
+    obj2 = object_in_world.ObjectInWorld.create(1.5,1.5,3)[1]
+    obj3 = object_in_world.ObjectInWorld.create(4,4,7)[1]
+    obj4 = object_in_world.ObjectInWorld.create(-4,-4,5)[1]
+    obj5 = object_in_world.ObjectInWorld.create(5,5,9)[1]
+    detections2 = [obj1, obj2, obj3, obj4, obj5]
+    yield detections2
+
+
+class TestLandingPadTracking:
+    """
+    Test landing pad tracking run function
+    """
+    # pylint: disable=protected-access
+    def test_is_similar(self):
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-1,-1,0)[1]
+        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(1,1,0)[1]
+        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(0.5,0.5,0)[1]
+        assert landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-0.5,-0.5,0)[1]
+        assert landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(2,2,0)[1]
+        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+        obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
+        obj2 = object_in_world.ObjectInWorld.create(-2,-2,0)[1]
+        assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)
+
+    def test_run_with_empty_detections_list(self, tracker: landing_pad_tracking.LandingPadTracking):
+        """
+        Test run method with empty detections list
+        """
+        success_flag, result = tracker.run([])
+        assert not success_flag
+        assert result is None
+
+    def test_run_single_input(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test run with only 1 input
+        """
+        success_flag, result = tracker.run(detections1)
+        assert success_flag
+        assert result == detections1[2]
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+
+    def test_run_single_input_similar_detections(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test run with only 1 input where 2 landing pads are similar
+        """        
+        detections1[1] = object_in_world.ObjectInWorld.create(0.5, 0.5, 4)[1]
+        success_flag, result = tracker.run(detections1)
+        print(detections1[2].spherical_variance, result.spherical_variance)
+        assert success_flag
+        assert result == detections1[2]
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[3]]
+
+    def test_run_multiple_inputs(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]", detections2: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test run with 2 inputs where some landing pads are similar
+        """
+        success_flag, result = tracker.run(detections1)
+        assert success_flag
+        assert result == detections1[2]
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+
+        success_flag, result = tracker.run(detections2)
+        assert success_flag
+        assert result == detections2[0]
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[0], detections1[2], detections2[1], detections2[3], detections1[4], detections2[2], detections2[4], detections1[3]]

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -110,3 +110,27 @@ class TestLandingPadTracking:
         assert success_flag
         assert result == detections2[0]
         assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[0], detections1[2], detections2[1], detections2[3], detections1[4], detections2[2], detections2[4], detections1[3]]
+
+    def test_run_with_confirmed_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test run when there is a confirmed positive
+        """
+        confirmed_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        tracker.mark_confirmed_positive(confirmed_positive)
+        assert tracker._LandingPadTracking__confirmed_positives[0] == confirmed_positive
+        success_flag, result = tracker.run(detections1)
+        assert success_flag
+        assert result == confirmed_positive
+    
+    def test_mark_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test if marking false positives removes similar landing pads
+        """
+        false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        tracker.run(detections2)
+        tracker.mark_false_positive(false_positive)
+        assert tracker._LandingPadTracking__false_positives[0] == false_positive
+        for i in tracker._LandingPadTracking__unconfirmed_positives:
+            print(i.spherical_variance)
+        print(tracker._LandingPadTracking__is_similar(false_positive, detections2[1], DISTANCE_SQUARED_THRESHOLD))
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[3], detections2[2], detections2[4]]

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -130,7 +130,14 @@ class TestLandingPadTracking:
         tracker.run(detections2)
         tracker.mark_false_positive(false_positive)
         assert tracker._LandingPadTracking__false_positives[0] == false_positive
-        for i in tracker._LandingPadTracking__unconfirmed_positives:
-            print(i.spherical_variance)
-        print(tracker._LandingPadTracking__is_similar(false_positive, detections2[1], DISTANCE_SQUARED_THRESHOLD))
+        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[3], detections2[2], detections2[4]]
+    
+    def test_run_with_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test to see if run function doesn't add landing pads that are similar to false positives
+        """
+        false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        tracker.mark_false_positive(false_positive)
+        tracker.run(detections2)
+        assert tracker._LandingPadTracking__false_positives[0] == false_positive
         assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[3], detections2[2], detections2[4]]

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -180,11 +180,11 @@ class TestMarkFalsePositive:
         """
         Test if marking false positive adds detection to list of false positives
         """
-        false_positive1 = object_in_world.ObjectInWorld.create(20, 20, 1)[1]
-        false_positive2 = object_in_world.ObjectInWorld.create(40, 40, 1)[1]
+        false_positive1 = object_in_world.ObjectInWorld.create(0, 0, 1)[1]
+        false_positive2 = object_in_world.ObjectInWorld.create(2, 2, 1)[1]
         tracker._LandingPadTracking__unconfirmed_positives = detections1
         expected = [false_positive1, false_positive2]
-        expected_unconfirmed_positives = [detections1[0], detections1[1], detections1[2], detections1[3], detections1[4]]
+        expected_unconfirmed_positives = [detections1[2], detections1[3], detections1[4]]
         
         tracker.mark_false_positive(false_positive1)
         tracker.mark_false_positive(false_positive2)

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -65,7 +65,8 @@ class TestSimilar:
     """
     Test if similar function correctly determines if 2 landing pads are close enough to be considered similar
     """
-
+    # Required for testing
+    # pylint: disable=protected-access
     def test_is_similar_positive_equal_to_threshold(self):
         """
         Test case where the second landing pad has positive coordinates and the distance between them is equal to the distance threshold
@@ -138,6 +139,49 @@ class TestSimilar:
 
         assert actual == expected
 
+    # pylint: enable=protected-access
+
+class TestMarkFalsePositive:
+    """
+    Test if landing pad tracking correctly marks a detection as a false positive
+    """
+    # Required for testing
+    # pylint: disable=protected-access
+    def test_mark_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
+        """
+        Test if marking false positive adds detection to list of false positives and removes similar landing pads
+        """
+        false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        tracker._LandingPadTracking__unconfirmed_positives = detections2
+        expected = false_positive
+        expected_unconfirmed_positives = [detections2[2], detections2[3], detections2[4]]
+        
+        tracker.mark_false_positive(false_positive)
+
+        assert tracker._LandingPadTracking__false_positives[0] == expected
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
+    
+    # pylint: enable=protected-access
+
+class TestMarkConfirmedPositive:
+    """
+    Test if landing pad tracking correctly marks a detection as a confirmed positive
+    """
+    # Required for testing
+    # pylint: disable=protected-access
+    def test_mark_confirmed_positive(self, tracker:landing_pad_tracking.LandingPadTracking):
+        """
+        Test if marking confirmed positive adds detection to list of confirmed positives
+        """
+        confirmed_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        expected = confirmed_positive
+        
+        tracker.mark_confirmed_positive(confirmed_positive)
+
+        assert tracker._LandingPadTracking__confirmed_positives[0] == expected
+
+    # pylint: enable=protected-access
+
 class TestLandingPadTracking:
     """
     Test landing pad tracking run function
@@ -198,42 +242,24 @@ class TestLandingPadTracking:
         Test run when there is a confirmed positive
         """
         confirmed_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        tracker._LandingPadTracking__confirmed_positives.append(confirmed_positive)
         expected = confirmed_positive
 
-        tracker.mark_confirmed_positive(confirmed_positive)
         result, actual = tracker.run(detections1)
         
         assert result
-        assert tracker._LandingPadTracking__confirmed_positives[0] == expected
         assert actual == expected
-    
-    def test_mark_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
-        """
-        Test if marking false positive adds detection to list of false positives removes similar landing pads
-        """
-        false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
-        expected = false_positive
-        expected_unconfirmed_positives = [detections2[3], detections2[2], detections2[4]]
-        
-        tracker.run(detections2)
-        tracker.mark_false_positive(false_positive)
-        
-        assert tracker._LandingPadTracking__false_positives[0] == expected
-        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
     def test_run_with_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test to see if run function doesn't add landing pads that are similar to false positives
         """
-        false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
-        expected = false_positive
+        tracker._LandingPadTracking__false_positives.append(object_in_world.ObjectInWorld.create(1, 1, 1)[1])
         expected_unconfirmed_positives = [detections2[3], detections2[2], detections2[4]]
 
-        
-        tracker.mark_false_positive(false_positive)
         tracker.run(detections2)
         
-        assert tracker._LandingPadTracking__false_positives[0] == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
     # pylint: enable=protected-access
+

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -50,6 +50,9 @@ class TestLandingPadTracking:
     """
     # pylint: disable=protected-access
     def test_is_similar(self):
+        """
+        Test if similar function correctly determines if 2 landing pads are close enough to be considered similar
+        """
         obj1 = object_in_world.ObjectInWorld.create(0,0,0)[1]
         obj2 = object_in_world.ObjectInWorld.create(-1,-1,0)[1]
         assert not landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(obj1, obj2, DISTANCE_SQUARED_THRESHOLD)

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -19,6 +19,7 @@ def tracker():
     tracker = landing_pad_tracking.LandingPadTracking(DISTANCE_SQUARED_THRESHOLD)
     yield tracker
 
+
 @pytest.fixture
 def detections1():
     """
@@ -33,6 +34,7 @@ def detections1():
     detections1 = [obj1, obj2, obj3, obj4, obj5]
     yield detections1
 
+
 @pytest.fixture
 def detections2():
     """
@@ -46,6 +48,7 @@ def detections2():
     assert result1 and result2 and result3 and result4 and result5
     detections2 = [obj1, obj2, obj3, obj4, obj5]
     yield detections2
+
 
 @pytest.fixture
 def detections3():
@@ -201,10 +204,9 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_mark_false_positive_with_similar(
-        self,
-        tracker: landing_pad_tracking.LandingPadTracking,
-        detections2: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_false_positive_with_similar(self,
+                                              tracker: landing_pad_tracking.LandingPadTracking,
+                                              detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives and removes
         similar landing pads
@@ -219,10 +221,9 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
-    def test_mark_multiple_false_positive(
-        self,
-        tracker: landing_pad_tracking.LandingPadTracking,
-        detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_multiple_false_positive(self,
+                                          tracker: landing_pad_tracking.LandingPadTracking,
+                                          detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives
         """
@@ -290,8 +291,8 @@ class TestLandingPadTracking:
         assert actual is None
 
     def test_run_one_input(self,
-                              tracker: landing_pad_tracking.LandingPadTracking,
-                              detections1: "list[object_in_world.ObjectInWorld]"):
+                           tracker: landing_pad_tracking.LandingPadTracking,
+                           detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with only 1 input
         """

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -22,7 +22,7 @@ def tracker():
 @pytest.fixture
 def detections1():
     """
-    Sample instances of 'object_in_world.ObjectInWorld' for testing
+    Sample instances of ObjectInWorld for testing
     """
     result1, obj1 = object_in_world.ObjectInWorld.create(0,0,8)
     result2, obj2 = object_in_world.ObjectInWorld.create(2,2,4)
@@ -36,7 +36,7 @@ def detections1():
 @pytest.fixture
 def detections2():
     """
-    Sample instances of 'object_in_world.ObjectInWorld' for testing
+    Sample instances of ObjectInWorld for testing
     """
     result1, obj1 = object_in_world.ObjectInWorld.create(0.5,0.5,1)
     result2, obj2 = object_in_world.ObjectInWorld.create(1.5,1.5,3)
@@ -50,7 +50,7 @@ def detections2():
 @pytest.fixture
 def detections3():
     """
-    Sample instances of 'object_in_world.ObjectInWorld' for testing
+    Sample instances of ObjectInWorld for testing
     """
     result1, obj1 = object_in_world.ObjectInWorld.create(0,0,8)
     result2, obj2 = object_in_world.ObjectInWorld.create(0.5,0.5,4)
@@ -79,7 +79,9 @@ class TestSimilar:
         expected = False
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
         )
 
         assert actual == expected
@@ -94,7 +96,9 @@ class TestSimilar:
         expected = False
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
         )
 
         assert actual == expected
@@ -109,7 +113,9 @@ class TestSimilar:
         expected = True
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
         )
 
         assert actual == expected
@@ -124,8 +130,10 @@ class TestSimilar:
         expected = True
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
-            )
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
+        )
 
         assert actual == expected
 
@@ -139,8 +147,10 @@ class TestSimilar:
         expected = False
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
-            )
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
+        )
 
         assert actual == expected
 
@@ -154,7 +164,9 @@ class TestSimilar:
         expected = False
 
         actual = landing_pad_tracking.LandingPadTracking._LandingPadTracking__is_similar(
-            obj1, obj2, DISTANCE_SQUARED_THRESHOLD
+            obj1,
+            obj2,
+            DISTANCE_SQUARED_THRESHOLD,
         )
 
         assert actual == expected
@@ -181,7 +193,7 @@ class TestMarkFalsePositive:
             detections1[1],
             detections1[2],
             detections1[3],
-            detections1[4]
+            detections1[4],
         ]
         
         tracker.mark_false_positive(false_positive)
@@ -189,9 +201,10 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_mark_false_positive_with_similar(self,
-                                              tracker: landing_pad_tracking.LandingPadTracking,
-                                              detections2: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_false_positive_with_similar(
+        self,
+        tracker: landing_pad_tracking.LandingPadTracking,
+        detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives and removes
         similar landing pads
@@ -206,9 +219,10 @@ class TestMarkFalsePositive:
         assert tracker._LandingPadTracking__false_positives == expected
         assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
-    def test_mark_multiple_false_positive(self,
-                                          tracker: landing_pad_tracking.LandingPadTracking,
-                                          detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_mark_multiple_false_positive(
+        self,
+        tracker: landing_pad_tracking.LandingPadTracking,
+        detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test if marking false positive adds detection to list of false positives
         """
@@ -287,7 +301,7 @@ class TestLandingPadTracking:
             detections1[1],
             detections1[4],
             detections1[0],
-            detections1[3]
+            detections1[3],
         ]
         
         result, actual = tracker.run(detections1)
@@ -307,7 +321,7 @@ class TestLandingPadTracking:
             detections3[2],
             detections3[1],
             detections3[4],
-            detections3[3]
+            detections3[3],
         ]
         
         result, actual = tracker.run(detections3)
@@ -332,7 +346,7 @@ class TestLandingPadTracking:
             detections1[4],
             detections2[2],
             detections2[4],
-            detections1[3]
+            detections1[3],
         ]
 
         tracker.run(detections1)

--- a/tests/test_landing_pad_tracking.py
+++ b/tests/test_landing_pad_tracking.py
@@ -7,12 +7,14 @@ import pytest
 from modules import object_in_world
 from modules.controller import landing_pad_tracking
 
+
 DISTANCE_SQUARED_THRESHOLD = 2
+
 
 @pytest.fixture()
 def tracker():
     """
-    instantiates model tracking
+    Instantiates model tracking
     """
     tracker = landing_pad_tracking.LandingPadTracking(DISTANCE_SQUARED_THRESHOLD)
     yield tracker
@@ -20,13 +22,14 @@ def tracker():
 @pytest.fixture
 def detections1():
     """
-    # Sample instances of 'object_in_world.ObjectInWorld' for testing
+    Sample instances of 'object_in_world.ObjectInWorld' for testing
     """
-    obj1 = object_in_world.ObjectInWorld.create(0,0,8)[1]
-    obj2 = object_in_world.ObjectInWorld.create(2,2,4)[1]
-    obj3 = object_in_world.ObjectInWorld.create(-2,-2,2)[1]
-    obj4 = object_in_world.ObjectInWorld.create(3,3,10)[1]
-    obj5 = object_in_world.ObjectInWorld.create(-3,-3,6)[1]
+    result1, obj1 = object_in_world.ObjectInWorld.create(0,0,8)
+    result2, obj2 = object_in_world.ObjectInWorld.create(2,2,4)
+    result3, obj3 = object_in_world.ObjectInWorld.create(-2,-2,2)
+    result4, obj4 = object_in_world.ObjectInWorld.create(3,3,10)
+    result5, obj5 = object_in_world.ObjectInWorld.create(-3,-3,6)
+    assert result1 and result2 and result3 and result4 and result5
     detections1 = [obj1, obj2, obj3, obj4, obj5]
     yield detections1
 
@@ -35,19 +38,34 @@ def detections2():
     """
     Sample instances of 'object_in_world.ObjectInWorld' for testing
     """
-    obj1 = object_in_world.ObjectInWorld.create(0.5,0.5,1)[1]
-    obj2 = object_in_world.ObjectInWorld.create(1.5,1.5,3)[1]
-    obj3 = object_in_world.ObjectInWorld.create(4,4,7)[1]
-    obj4 = object_in_world.ObjectInWorld.create(-4,-4,5)[1]
-    obj5 = object_in_world.ObjectInWorld.create(5,5,9)[1]
+    result1, obj1 = object_in_world.ObjectInWorld.create(0.5,0.5,1)
+    result2, obj2 = object_in_world.ObjectInWorld.create(1.5,1.5,3)
+    result3, obj3 = object_in_world.ObjectInWorld.create(4,4,7)
+    result4, obj4 = object_in_world.ObjectInWorld.create(-4,-4,5)
+    result5, obj5 = object_in_world.ObjectInWorld.create(5,5,9)
+    assert result1 and result2 and result3 and result4 and result5
     detections2 = [obj1, obj2, obj3, obj4, obj5]
     yield detections2
 
+@pytest.fixture
+def detections3():
+    """
+    Sample instances of 'object_in_world.ObjectInWorld' for testing
+    """
+    result1, obj1 = object_in_world.ObjectInWorld.create(0,0,8)
+    result2, obj2 = object_in_world.ObjectInWorld.create(0.5,0.5,4)
+    result3, obj3 = object_in_world.ObjectInWorld.create(-2,-2,2)
+    result4, obj4 = object_in_world.ObjectInWorld.create(3,3,10)
+    result5, obj5 = object_in_world.ObjectInWorld.create(-3,-3,6)
+    assert result1 and result2 and result3 and result4 and result5
+    detections3 = [obj1, obj2, obj3, obj4, obj5]
+    yield detections3
 
 class TestLandingPadTracking:
     """
     Test landing pad tracking run function
     """
+    # Required for testing
     # pylint: disable=protected-access
     def test_is_similar(self):
         """
@@ -76,71 +94,92 @@ class TestLandingPadTracking:
         """
         Test run method with empty detections list
         """
-        success_flag, result = tracker.run([])
-        assert not success_flag
-        assert result is None
+        result, actual = tracker.run([])
+        assert not result
+        assert actual is None
 
     def test_run_single_input(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with only 1 input
         """
-        success_flag, result = tracker.run(detections1)
-        assert success_flag
-        assert result == detections1[2]
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+        expected_output = detections1[2]
+        expected_unconfirmed_positives = [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+        
+        result, actual = tracker.run(detections1)
+        
+        assert result
+        assert actual  == expected_output
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
-    def test_run_single_input_similar_detections(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
+    def test_run_single_input_similar_detections(self, tracker: landing_pad_tracking.LandingPadTracking, detections3: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with only 1 input where 2 landing pads are similar
         """        
-        detections1[1] = object_in_world.ObjectInWorld.create(0.5, 0.5, 4)[1]
-        success_flag, result = tracker.run(detections1)
-        print(detections1[2].spherical_variance, result.spherical_variance)
-        assert success_flag
-        assert result == detections1[2]
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[3]]
+        expected_output = detections3[2]
+        expected_unconfirmed_positives = [detections3[2], detections3[1], detections3[4], detections3[3]]
+        
+        result, actual = tracker.run(detections3)
+
+        assert result
+        assert actual == expected_output
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
     def test_run_multiple_inputs(self, tracker: landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]", detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test run with 2 inputs where some landing pads are similar
         """
-        success_flag, result = tracker.run(detections1)
-        assert success_flag
-        assert result == detections1[2]
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections1[2], detections1[1], detections1[4], detections1[0], detections1[3]]
+        expected_output = detections2[0]
+        expected_unconfirmed_positives = [detections2[0], detections1[2], detections2[1], detections2[3], detections1[4], detections2[2], detections2[4], detections1[3]]
 
-        success_flag, result = tracker.run(detections2)
-        assert success_flag
-        assert result == detections2[0]
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[0], detections1[2], detections2[1], detections2[3], detections1[4], detections2[2], detections2[4], detections1[3]]
+
+        tracker.run(detections1)
+        result, actual = tracker.run(detections2)
+
+        assert result
+        assert actual == expected_output
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
 
     def test_run_with_confirmed_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections1: "list[object_in_world.ObjectInWorld]"):
         """
         Test run when there is a confirmed positive
         """
         confirmed_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        expected = confirmed_positive
+
         tracker.mark_confirmed_positive(confirmed_positive)
-        assert tracker._LandingPadTracking__confirmed_positives[0] == confirmed_positive
-        success_flag, result = tracker.run(detections1)
-        assert success_flag
-        assert result == confirmed_positive
+        result, actual = tracker.run(detections1)
+        
+        assert result
+        assert tracker._LandingPadTracking__confirmed_positives[0] == expected
+        assert actual == expected
     
     def test_mark_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
         """
-        Test if marking false positives removes similar landing pads
+        Test if marking false positive adds detection to list of false positives removes similar landing pads
         """
         false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        expected = false_positive
+        expected_unconfirmed_positives = [detections2[3], detections2[2], detections2[4]]
+        
         tracker.run(detections2)
         tracker.mark_false_positive(false_positive)
-        assert tracker._LandingPadTracking__false_positives[0] == false_positive
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[3], detections2[2], detections2[4]]
+        
+        assert tracker._LandingPadTracking__false_positives[0] == expected
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
     
     def test_run_with_false_positive(self, tracker:landing_pad_tracking.LandingPadTracking, detections2: "list[object_in_world.ObjectInWorld]"):
         """
         Test to see if run function doesn't add landing pads that are similar to false positives
         """
         false_positive = object_in_world.ObjectInWorld.create(1, 1, 1)[1]
+        expected = false_positive
+        expected_unconfirmed_positives = [detections2[3], detections2[2], detections2[4]]
+
+        
         tracker.mark_false_positive(false_positive)
         tracker.run(detections2)
-        assert tracker._LandingPadTracking__false_positives[0] == false_positive
-        assert tracker._LandingPadTracking__unconfirmed_positives == [detections2[3], detections2[2], detections2[4]]
+        
+        assert tracker._LandingPadTracking__false_positives[0] == expected
+        assert tracker._LandingPadTracking__unconfirmed_positives == expected_unconfirmed_positives
+
+    # pylint: enable=protected-access


### PR DESCRIPTION
Added world_tracking_model.py, which tracks the landing pad detections output from the GMM so that the drone won't visit the same false positive landing pad more than once.
It outputs the landing pad the drone should visit next, or None if there aren't any landing pads left in the list to visit.
It will also store the confirmed positive landing pad so it can be reused in the future.