### PR TITLE
Added baud rate parameter in `config.yaml`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ detect_target:
 flight_interface:
     address: "tcp:127.0.0.1:14550"
     timeout: 10.0  # seconds
+    baud_rate: 57600  # symbol rate 
     worker_period: 0.1  # seconds
 
 data_merge:

--- a/main_2024.py
+++ b/main_2024.py
@@ -88,6 +88,7 @@ def main() -> int:
 
         FLIGHT_INTERFACE_ADDRESS = config["flight_interface"]["address"]
         FLIGHT_INTERFACE_TIMEOUT = config["flight_interface"]["timeout"]
+        FLIGHT_INTERFACE_BAUD_RATE = config["flight_interface"]["baud_rate"]
         FLIGHT_INTERFACE_WORKER_PERIOD = config["flight_interface"]["worker_period"]
 
         DATA_MERGE_TIMEOUT = config["data_merge"]["timeout"]
@@ -176,6 +177,7 @@ def main() -> int:
         (
             FLIGHT_INTERFACE_ADDRESS,
             FLIGHT_INTERFACE_TIMEOUT,
+            FLIGHT_INTERFACE_BAUD_RATE,
             FLIGHT_INTERFACE_WORKER_PERIOD,
             flight_interface_to_data_merge_queue,
             controller,

--- a/modules/flight_interface/flight_interface.py
+++ b/modules/flight_interface/flight_interface.py
@@ -19,7 +19,9 @@ class FlightInterface:
     __create_key = object()
 
     @classmethod
-    def create(cls, address: str, timeout_home: float, baud_rate: int) -> "tuple[bool, FlightInterface | None]":
+    def create(
+        cls, address: str, timeout_home: float, baud_rate: int
+    ) -> "tuple[bool, FlightInterface | None]":
         """
         address: TCP address or port.
         timeout_home: Timeout for home location in seconds.

--- a/modules/flight_interface/flight_interface.py
+++ b/modules/flight_interface/flight_interface.py
@@ -19,10 +19,11 @@ class FlightInterface:
     __create_key = object()
 
     @classmethod
-    def create(cls, address: str, timeout_home: float) -> "tuple[bool, FlightInterface | None]":
+    def create(cls, address: str, timeout_home: float, baud_rate: int) -> "tuple[bool, FlightInterface | None]":
         """
         address: TCP address or port.
         timeout_home: Timeout for home location in seconds.
+        baud_rate: Baud rate for the connection.
         """
         result, flight_interface_logger = logger.Logger.create("flight_interface")
         if not result:
@@ -34,7 +35,7 @@ class FlightInterface:
         frame = inspect.currentframe()
         flight_interface_logger.info("flight interface logger initialized", frame)
 
-        result, controller = flight_controller.FlightController.create(address)
+        result, controller = flight_controller.FlightController.create(address, baud_rate)
         if not result:
             frame = inspect.currentframe()
             flight_interface_logger.error("controller could not be created", frame)

--- a/modules/flight_interface/flight_interface_worker.py
+++ b/modules/flight_interface/flight_interface_worker.py
@@ -12,6 +12,7 @@ from . import flight_interface
 def flight_interface_worker(
     address: str,
     timeout: float,
+    baud_rate: int,
     period: float,
     output_queue: queue_proxy_wrapper.QueueProxyWrapper,
     controller: worker_controller.WorkerController,
@@ -27,7 +28,7 @@ def flight_interface_worker(
     # TODO: Error handling
     # TODO: Logging
 
-    result, interface = flight_interface.FlightInterface.create(address, timeout)
+    result, interface = flight_interface.FlightInterface.create(address, timeout, baud_rate)
     if not result:
         print("ERROR: Worker failed to create class object")
         return

--- a/tests/integration/test_flight_interface_hardware.py
+++ b/tests/integration/test_flight_interface_hardware.py
@@ -7,6 +7,7 @@ from modules.flight_interface import flight_interface
 
 MAVLINK_CONNECTION_ADDRESS = "tcp:localhost:14550"
 FLIGHT_INTERFACE_TIMEOUT = 10.0  # seconds
+FLIGHT_INTERFACE_BAUD_RATE = 57600  # symbol rate
 
 
 def main() -> int:
@@ -17,6 +18,7 @@ def main() -> int:
     result, interface = flight_interface.FlightInterface.create(
         MAVLINK_CONNECTION_ADDRESS,
         FLIGHT_INTERFACE_TIMEOUT,
+        FLIGHT_INTERFACE_BAUD_RATE,
     )
     assert result
     assert interface is not None

--- a/tests/integration/test_flight_interface_worker.py
+++ b/tests/integration/test_flight_interface_worker.py
@@ -14,6 +14,7 @@ from utilities.workers import worker_controller
 
 MAVLINK_CONNECTION_ADDRESS = "tcp:localhost:14550"
 FLIGHT_INTERFACE_TIMEOUT = 10.0  # seconds
+FLIGHT_INTERFACE_BAUD_RATE = 57600  # symbol rate
 FLIGHT_INTERFACE_WORKER_PERIOD = 0.1  # seconds
 
 
@@ -33,6 +34,7 @@ def main() -> int:
         args=(
             MAVLINK_CONNECTION_ADDRESS,
             FLIGHT_INTERFACE_TIMEOUT,
+            FLIGHT_INTERFACE_BAUD_RATE,
             FLIGHT_INTERFACE_WORKER_PERIOD,
             out_queue,
             controller,


### PR DESCRIPTION
## Added baud rate parameter in `config.yaml`

**Key Changes**
- Added `BAUD_RATE` parameter in `config.yaml` and propagated the value to flight interface module
- Updated common repo to get latest updates from `FlightController`
- Fixed test cases and added baud rate parameter

**Testing**
- All unit tests pass
- Tested `test_flight_interface_worker` and `test_flight_interface_hardware` integration tests and confirmed they work