### PR TITLE
Geolocation Logging

### DIFF
--- a/modules/detection_in_world.py
+++ b/modules/detection_in_world.py
@@ -52,3 +52,9 @@ class DetectionInWorld:
         self.centre = centre
         self.label = label
         self.confidence = confidence
+
+    def __str__(self) -> str:
+        """
+        To string.
+        """
+        return f"{self.__class__}, vertices: {self.vertices.tolist()}, centre: {self.centre}, label: {self.label}, confidence: {self.confidence}"

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -9,6 +9,7 @@ from . import camera_properties
 from .. import detection_in_world
 from .. import detections_and_time
 from .. import merged_odometry_detections
+from ..common.logger.modules import logger
 
 
 class Geolocation:
@@ -25,6 +26,7 @@ class Geolocation:
         cls,
         camera_intrinsics: camera_properties.CameraIntrinsics,
         camera_drone_extrinsics: camera_properties.CameraDroneExtrinsics,
+        local_logger: logger.Logger,
     ) -> "tuple[bool, Geolocation | None]":
         """
         camera_intrinsics: Camera information without any outside space.
@@ -59,6 +61,7 @@ class Geolocation:
             camera_drone_extrinsics,
             perspective_transform_sources,
             rotated_source_vectors,
+            local_logger,
         )
 
     def __init__(
@@ -67,6 +70,7 @@ class Geolocation:
         camera_drone_extrinsics: camera_properties.CameraDroneExtrinsics,
         perspective_transform_sources: "list[list[float]]",
         rotated_source_vectors: "list[np.ndarray]",
+        local_logger: logger.Logger,
     ) -> None:
         """
         Private constructor, use create() method.
@@ -76,6 +80,7 @@ class Geolocation:
         self.__camera_drone_extrinsics = camera_drone_extrinsics
         self.__perspective_transform_sources = perspective_transform_sources
         self.__rotated_source_vectors = rotated_source_vectors
+        self.__logger = local_logger
 
     @staticmethod
     def __ground_intersection_from_vector(

--- a/modules/geolocation/geolocation.py
+++ b/modules/geolocation/geolocation.py
@@ -99,7 +99,7 @@ class Geolocation:
             return False, None
 
         if not camera_properties.is_vector_r3(vec_down):
-            logger.error("Rotated source vector in world space is not a vector in R3")
+            local_logger.error("Rotated source vector in world space is not a vector in R3")
             return False, None
 
         # Check camera above ground
@@ -176,14 +176,10 @@ class Geolocation:
                 dst,
             )
         # All exceptions must be caught and logged as early as possible
-        # pylint: disable-next=catching-non-exception
-        except cv2.error as e:
-            self.__logger.error(f"Could not get perspective transform matrix: {e}")
-            return False, None
-        # All exceptions must be caught and logged as early as possible
         # pylint: disable-next=broad-exception-caught
         except Exception as e:
             self.__logger.error(f"Could not get perspective transform matrix: {e}")
+            return False, None
 
         return True, matrix
 

--- a/modules/geolocation/geolocation_worker.py
+++ b/modules/geolocation/geolocation_worker.py
@@ -2,10 +2,14 @@
 Convert bounding box data into ground data.
 """
 
+import os
+import pathlib
+
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
 from . import camera_properties
 from . import geolocation
+from ..common.logger.modules import logger
 
 
 def geolocation_worker(
@@ -24,12 +28,24 @@ def geolocation_worker(
     # TODO: Logging?
     # TODO: Handle errors better
 
+    worker_name = pathlib.Path(__file__).stem
+    process_id = os.getpid()
+    result, local_logger = logger.Logger.create(f"{worker_name}_{process_id}", True)
+    if not result:
+        print("ERROR: Worker failed to create logger")
+        return
+
+    assert local_logger is not None
+
+    local_logger.info("Logger initialized")
+
     result, locator = geolocation.Geolocation.create(
         camera_intrinsics,
         camera_drone_extrinsics,
+        local_logger,
     )
     if not result:
-        print("Worker failed to create class object")
+        local_logger.error("Worker failed to create class object")
         return
 
     # Get Pylance to stop complaining

--- a/modules/geolocation/geolocation_worker.py
+++ b/modules/geolocation/geolocation_worker.py
@@ -25,7 +25,6 @@ def geolocation_worker(
     input_queue and output_queue are data queues.
     controller is how the main process communicates to this worker process.
     """
-    # TODO: Logging?
     # TODO: Handle errors better
 
     worker_name = pathlib.Path(__file__).stem

--- a/tests/unit/test_geolocation.py
+++ b/tests/unit/test_geolocation.py
@@ -281,6 +281,10 @@ class TestGroundIntersection:
         Above origin, directly down.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([0.0, 0.0, -100.0], dtype=np.float32)
         vec_down = np.array([0.0, 0.0, 1.0], dtype=np.float32)
 
@@ -293,6 +297,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_down,
+            test_logger,
         )
 
         # Test
@@ -305,6 +310,10 @@ class TestGroundIntersection:
         Directly down.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([100.0, -100.0, -100.0], dtype=np.float32)
         vec_down = np.array([0.0, 0.0, 1.0], dtype=np.float32)
 
@@ -317,6 +326,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_down,
+            test_logger,
         )
 
         # Test
@@ -329,6 +339,10 @@ class TestGroundIntersection:
         Above origin, angled down towards positive.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([0.0, 0.0, -100.0], dtype=np.float32)
         vec_down = np.array([1.0, 1.0, 1.0], dtype=np.float32)
 
@@ -341,6 +355,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_down,
+            test_logger,
         )
 
         # Test
@@ -353,6 +368,10 @@ class TestGroundIntersection:
         Angled down towards origin.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([100.0, -100.0, -100.0], dtype=np.float32)
         vec_down = np.array([-1.0, 1.0, 1.0], dtype=np.float32)
 
@@ -365,6 +384,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_down,
+            test_logger,
         )
 
         # Test
@@ -377,6 +397,10 @@ class TestGroundIntersection:
         False, None .
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([0.0, 0.0, -100.0], dtype=np.float32)
         vec_horizontal = np.array([10.0, 0.0, 1.0], dtype=np.float32)
 
@@ -387,6 +411,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_horizontal,
+            test_logger,
         )
 
         # Test
@@ -398,6 +423,10 @@ class TestGroundIntersection:
         False, None .
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_camera_in_world_position = np.array([0.0, 0.0, -100.0], dtype=np.float32)
         vec_up = np.array([0.0, 0.0, -1.0], dtype=np.float32)
 
@@ -408,6 +437,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_camera_in_world_position,
             vec_up,
+            test_logger,
         )
 
         # Test
@@ -419,6 +449,10 @@ class TestGroundIntersection:
         False, None .
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         vec_underground = np.array([0.0, 0.0, 1.0], dtype=np.float32)
         vec_down = np.array([0.0, 0.0, 1.0], dtype=np.float32)
 
@@ -429,6 +463,7 @@ class TestGroundIntersection:
         ) = geolocation.Geolocation._Geolocation__ground_intersection_from_vector(  # type: ignore
             vec_underground,
             vec_down,
+            test_logger,
         )
 
         # Test
@@ -668,6 +703,10 @@ class TestGeolocationConvertDetection:
         Normal detection and matrix.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         result, expected = detection_in_world.DetectionInWorld.create(
             # fmt: off
             np.array(
@@ -697,6 +736,7 @@ class TestGeolocationConvertDetection:
         ) = geolocation.Geolocation._Geolocation__convert_detection_to_world_from_image(  # type: ignore
             detection_1,
             affine_matrix,
+            test_logger,
         )
 
         # Test
@@ -715,6 +755,10 @@ class TestGeolocationConvertDetection:
         Normal detection and matrix.
         """
         # Setup
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         result, expected = detection_in_world.DetectionInWorld.create(
             # fmt: off
             np.array(
@@ -744,6 +788,7 @@ class TestGeolocationConvertDetection:
         ) = geolocation.Geolocation._Geolocation__convert_detection_to_world_from_image(  # type: ignore
             detection_2,
             affine_matrix,
+            test_logger,
         )
 
         # Test

--- a/tests/unit/test_geolocation.py
+++ b/tests/unit/test_geolocation.py
@@ -11,6 +11,7 @@ from modules import drone_odometry_local
 from modules import merged_odometry_detections
 from modules.geolocation import camera_properties
 from modules.geolocation import geolocation
+from modules.common.logger.modules import logger
 
 
 FLOAT_PRECISION_TOLERANCE = 4
@@ -42,9 +43,14 @@ def basic_locator() -> geolocation.Geolocation:  # type: ignore
     assert result
     assert camera_extrinsics is not None
 
+    result, test_logger = logger.Logger.create("test_logger", False)
+    assert result
+    assert test_logger is not None
+
     result, locator = geolocation.Geolocation.create(
         camera_intrinsics,
         camera_extrinsics,
+        test_logger,
     )
     assert result
     assert locator is not None
@@ -73,9 +79,14 @@ def intermediate_locator() -> geolocation.Geolocation:  # type: ignore
     assert result
     assert camera_extrinsics is not None
 
+    result, test_logger = logger.Logger.create("test_logger", False)
+    assert result
+    assert test_logger is not None
+
     result, locator = geolocation.Geolocation.create(
         camera_intrinsics,
         camera_extrinsics,
+        test_logger,
     )
     assert result
     assert locator is not None
@@ -105,9 +116,14 @@ def advanced_locator() -> geolocation.Geolocation:  # type: ignore
     assert result
     assert camera_extrinsics is not None
 
+    result, test_logger = logger.Logger.create("test_logger", False)
+    assert result
+    assert test_logger is not None
+
     result, locator = geolocation.Geolocation.create(
         camera_intrinsics,
         camera_extrinsics,
+        test_logger,
     )
     assert result
     assert locator is not None
@@ -242,9 +258,14 @@ class TestGeolocationCreate:
         assert result
         assert camera_extrinsics is not None
 
+        result, test_logger = logger.Logger.create("test_logger", False)
+        assert result
+        assert test_logger is not None
+
         result, locator = geolocation.Geolocation.create(
             camera_intrinsics,
             camera_extrinsics,
+            test_logger,
         )
         assert result
         assert locator is not None


### PR DESCRIPTION
## Add Logging to Geolocation

**Key Changes**
- Added logging to the geolocation module
  - **Note:** The logs are designed to only print out one error log per run ( 
- Added string representation for `DetectionInWorld`
- Updated test cases

**Testing**
- All unit tests pass
- Ran `test_geolocation_worker` integration test works and confirm logs are logged as expected

Output from log file
```
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation_worker.py | geolocation_worker | 40] Logger initialized
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0
05:08:50: [INFO] [C:\Users\Mihir\vscode_workspace\WARG\Repositories\computer-vision-python\modules\geolocation\geolocation.py | run | 324] <class 'modules.detection_in_world.DetectionInWorld'>, vertices: [[100.0, -100.00000000000001], [100.00000000000001, 100.00000000000001], [-100.0, -99.99999999999999], [-100.0, 99.99999999999999]], centre: [0. 0.], label: 1, confidence: 1.0


```