### PR TITLE
Restart worker patch with fixed commit history

### DIFF
--- a/modules/cluster_estimation/cluster_estimation_worker.py
+++ b/modules/cluster_estimation/cluster_estimation_worker.py
@@ -77,8 +77,8 @@ def cluster_estimation_worker(
 
         is_invalid = False
 
-        for input in input_data:
-            if not isinstance(input, detection_in_world.DetectionInWorld):
+        for single_input in input_data:
+            if not isinstance(single_input, detection_in_world.DetectionInWorld):
                 local_logger.warning(f"Skipping unexpected input: {input}")
                 is_invalid = True
                 break

--- a/modules/cluster_estimation/cluster_estimation_worker.py
+++ b/modules/cluster_estimation/cluster_estimation_worker.py
@@ -75,14 +75,14 @@ def cluster_estimation_worker(
             local_logger.info("Recieved type None, exiting.")
             break
 
-        isInvalid = False 
+        isInvalid = False
 
         for input in input_data:
             if not isinstance(input, detection_in_world.DetectionInWorld):
                 local_logger.warning(f"Skipping unexpected input: {input}")
                 isInvalid = True
                 break
-        
+
         if isInvalid:
             continue
 

--- a/modules/cluster_estimation/cluster_estimation_worker.py
+++ b/modules/cluster_estimation/cluster_estimation_worker.py
@@ -75,15 +75,15 @@ def cluster_estimation_worker(
             local_logger.info("Recieved type None, exiting.")
             break
 
-        isInvalid = False
+        is_invalid = False
 
         for input in input_data:
             if not isinstance(input, detection_in_world.DetectionInWorld):
                 local_logger.warning(f"Skipping unexpected input: {input}")
-                isInvalid = True
+                is_invalid = True
                 break
 
-        if isInvalid:
+        if is_invalid:
             continue
 
         # TODO: When to override

--- a/modules/cluster_estimation/cluster_estimation_worker.py
+++ b/modules/cluster_estimation/cluster_estimation_worker.py
@@ -5,6 +5,7 @@ Gets detections in world space and outputs estimations of objects.
 import os
 import pathlib
 
+from modules import detection_in_world
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
 from . import cluster_estimation
@@ -71,6 +72,18 @@ def cluster_estimation_worker(
 
         input_data = input_queue.queue.get()
         if input_data is None:
+            local_logger.info("Recieved type None, exiting.")
+            break
+
+        isInvalid = False 
+
+        for input in input_data:
+            if not isinstance(input, detection_in_world.DetectionInWorld):
+                local_logger.warning(f"Skipping unexpected input: {input}")
+                isInvalid = True
+                break
+        
+        if isInvalid:
             continue
 
         # TODO: When to override

--- a/modules/communications/communications_worker.py
+++ b/modules/communications/communications_worker.py
@@ -7,7 +7,6 @@ import pathlib
 import queue
 
 from modules import object_in_world
-
 from . import communications
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
@@ -78,7 +77,7 @@ def communications_worker(
         if is_invalid:
             continue
 
-        result, value = comm.run(input_queue.queue.get())
+        result, value = comm.run(input_data)
         if not result:
             continue
 

--- a/modules/communications/communications_worker.py
+++ b/modules/communications/communications_worker.py
@@ -6,6 +6,8 @@ import os
 import pathlib
 import queue
 
+from modules import object_in_world
+
 from . import communications
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
@@ -58,6 +60,23 @@ def communications_worker(
 
     while not controller.is_exit_requested():
         controller.check_pause()
+
+        input_data = input_queue.queue.get()
+
+        if input_data is None:
+            local_logger.info("Recieved type None, exiting.")
+            break
+
+        is_invalid = False
+
+        for single_input in input_data:
+            if not isinstance(single_input, object_in_world.ObjectInWorld):
+                local_logger.warning(f"Skipping unexpected input: {input}")
+                is_invalid = True
+                break
+
+        if is_invalid:
+            continue
 
         result, value = comm.run(input_queue.queue.get())
         if not result:

--- a/modules/detect_target/detect_target_worker.py
+++ b/modules/detect_target/detect_target_worker.py
@@ -5,6 +5,7 @@ Gets frames and outputs detections in image space.
 import os
 import pathlib
 
+from modules import image_and_time
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
 from . import detect_target_factory
@@ -64,7 +65,12 @@ def detect_target_worker(
 
         input_data = input_queue.queue.get()
         if input_data is None:
+            local_logger.info("Recieved type None, exiting.")
             break
+
+        if not isinstance(input_data, image_and_time.ImageAndTime):
+            local_logger.warning(f"Skipping unexpected input: {input}")
+            continue
 
         result, value = detector.run(input_data)
         if not result:

--- a/modules/geolocation/geolocation_worker.py
+++ b/modules/geolocation/geolocation_worker.py
@@ -5,6 +5,7 @@ Convert bounding box data into ground data.
 import os
 import pathlib
 
+from modules import merged_odometry_detections
 from utilities.workers import queue_proxy_wrapper
 from utilities.workers import worker_controller
 from . import camera_properties
@@ -55,7 +56,12 @@ def geolocation_worker(
 
         input_data = input_queue.queue.get()
         if input_data is None:
+            local_logger.info("Recieved type None, exiting.")
             break
+
+        if not isinstance(input_data, merged_odometry_detections.MergedOdometryDetections):
+            local_logger.warning(f"Skipping unexpected input: {input}")
+            continue
 
         result, value = locator.run(input_data)
         if not result:

--- a/utilities/workers/worker_manager.py
+++ b/utilities/workers/worker_manager.py
@@ -247,8 +247,8 @@ class WorkerManager:
         # Draining the preceding queue ensures that the preceding queue data wasn't what
         # caused the worker to fail. Draining the succeeding queues is not needed
         # because a worker that died would not have put bad data into the queue.
-        input_queues = self.__worker_properties.get_input_queues()
-        for queue in input_queues:
-            queue.drain_queue()
+        # input_queues = self.__worker_properties.get_input_queues()
+        # for queue in input_queues:
+        #     queue.drain_queue()
 
         return True


### PR DESCRIPTION
This is a new PR for the restart workers that fixes the messy commit history and implements some new changes.

Some things to note:
- I have only commented out the code that drains the queue just in case it is needed for the program to run
- Additionally, I don't quite understand how the queues are added to the new workers or if anything needs to be done to add them, so, if there are glaring flaws, I apologize